### PR TITLE
Fix street order for laposte

### DIFF
--- a/roulier/carriers/laposte/laposte_api.py
+++ b/roulier/carriers/laposte/laposte_api.py
@@ -52,11 +52,14 @@ class LaposteApi(Api):
         schema['country'].update({'required': True, 'empty': False})
         schema['zip'].update({'required': True, 'empty': False})
         schema['city'].update({'required': True, 'empty': False})
-        schema['street1'].update({
-            'required': False, 'empty': True,
-            'description': 'Entrée, bâtiment, immeuble, résidence'})
         schema['street0'] = {
             'default': '', 'description': 'Etage, couloir, escalier, appart.'}
+        schema['street1'].update({
+            'required': True, 'empty': False,
+            'description': 'Numéro et libellé de voie. Ex : 5 rue du Bellay'})
+        schema['street2'].update({
+            'required': False, 'empty': True,
+            'description': 'Entrée, bâtiment, immeuble, résidence'})
         schema['street3'] = {
             'default': '', 'description': """Lieu dit ou autre mention"""}
         schema['door1'] = {'default': '', 'description': """Code porte 1"""}

--- a/roulier/carriers/laposte/templates/laposte_address.xml
+++ b/roulier/carriers/laposte/templates/laposte_address.xml
@@ -3,8 +3,8 @@
 	<lastName>{{ address.name }}</lastName>
 	<firstName>{{ address.firstName }}</firstName>
 	<line0>{{ address.street0 }}</line0>
-	<line1>{{ address.street1 }}</line1>
-	<line2>{{ address.street2 }}</line2>
+	<line1>{{ address.street2 }}</line1>
+	<line2>{{ address.street1 }}</line2>
 	<line3>{{ address.street3 }}</line3>
 	<countryCode>{{ address.country }}</countryCode>
 	<city>{{ address.city }}</city>


### PR DESCRIPTION
Now : street1 (mandatory) = Ligne2
Because, usually street1 is the mandatory line in addresses