### PR TITLE
Fix lxml formats to python base formats

### DIFF
--- a/roulier/carriers/dpd/dpd_decoder.py
+++ b/roulier/carriers/dpd/dpd_decoder.py
@@ -3,7 +3,9 @@
 from lxml import objectify
 from roulier.codec import Decoder
 from roulier import ws_tools as tools
+from roulier.ws_tools import objectified_to_base_types
 import base64
+
 
 
 class DpdDecoder(Decoder):
@@ -47,7 +49,7 @@ class DpdDecoder(Decoder):
                     "type": summary_format
                 }]
             }
-            return x
+            return objectified_to_base_types(x)
 
         xml = objectify.fromstring(body)
         tag = xml.tag

--- a/roulier/carriers/geodis/geodis_decoder.py
+++ b/roulier/carriers/geodis/geodis_decoder.py
@@ -51,7 +51,7 @@ class GeodisDecoder(Decoder):
                 "region": localite.codeRegion,
                 "zip": localite.codePostal,
                 "city": localite.libelle,
-            } for localite in msg.infoLocalite]
+            } for localite in objectified_to_base_types(msg.infoLocalite)]
 
         tag = body.tag
         lookup = {

--- a/roulier/carriers/geodis/geodis_decoder.py
+++ b/roulier/carriers/geodis/geodis_decoder.py
@@ -47,10 +47,10 @@ class GeodisDecoder(Decoder):
 
         def response_find_localite(msg, parts):
             return [{
-                "ordre": localite.numOrdre,
-                "region": localite.codeRegion,
-                "zip": localite.codePostal,
-                "city": localite.libelle,
+                "ordre": localite.get('numOrdre'),
+                "region": localite.get('codeRegion'),
+                "zip": localite.get('codePostal'),
+                "city": localite.get('libelle'),
             } for localite in objectified_to_base_types(msg.infoLocalite)]
 
         tag = body.tag

--- a/roulier/carriers/laposte/laposte_decoder.py
+++ b/roulier/carriers/laposte/laposte_decoder.py
@@ -2,7 +2,7 @@
 """Laposte XML -> Python."""
 from lxml import objectify
 from roulier.codec import Decoder
-from roulier.ws_tools import sanitize_to_string
+from roulier.ws_tools import objectified_to_base_types
 
 
 class LaposteDecoder(Decoder):
@@ -27,8 +27,7 @@ class LaposteDecoder(Decoder):
                 href = element.getchildren()[0].attrib['href']
                 # href contains cid:236212...-38932@cfx.apache.org
                 return href[len('cid:'):]  # remove prefix
-
-            rep = msg.labelResponse
+            rep = objectified_to_base_types(msg.labelResponse)
             cn23_cid = get_cid('cn23', rep)
             label_cid = get_cid('label', rep)
 
@@ -48,7 +47,7 @@ class LaposteDecoder(Decoder):
                     "type": "url"
                 })
 
-            return sanitize_to_string({
+            return {
                 "tracking": {
                     "number": rep.parcelNumber,
                     "partner": rep.find('parcelNumberPartner'),
@@ -70,7 +69,7 @@ class LaposteDecoder(Decoder):
 
                 }],
                 "annexes": annexes
-            })
+            }
 
         xml = objectify.fromstring(body)
         tag = xml.tag

--- a/roulier/carriers/laposte/laposte_decoder.py
+++ b/roulier/carriers/laposte/laposte_decoder.py
@@ -2,6 +2,7 @@
 """Laposte XML -> Python."""
 from lxml import objectify
 from roulier.codec import Decoder
+from roulier.ws_tools import sanitize_to_string
 
 
 class LaposteDecoder(Decoder):
@@ -47,7 +48,7 @@ class LaposteDecoder(Decoder):
                     "type": "url"
                 })
 
-            return {
+            return sanitize_to_string({
                 "tracking": {
                     "number": rep.parcelNumber,
                     "partner": rep.find('parcelNumberPartner'),
@@ -69,7 +70,7 @@ class LaposteDecoder(Decoder):
 
                 }],
                 "annexes": annexes
-            }
+            })
 
         xml = objectify.fromstring(body)
         tag = xml.tag

--- a/roulier/carriers/laposte/laposte_decoder.py
+++ b/roulier/carriers/laposte/laposte_decoder.py
@@ -28,8 +28,8 @@ class LaposteDecoder(Decoder):
                 # href contains cid:236212...-38932@cfx.apache.org
                 return href[len('cid:'):]  # remove prefix
             rep = objectified_to_base_types(msg.labelResponse)
-            cn23_cid = get_cid('cn23', rep)
-            label_cid = get_cid('label', rep)
+            cn23_cid = get_cid('cn23', msg.labelResponse)
+            label_cid = get_cid('label', msg.labelResponse)
 
             annexes = []
 
@@ -40,17 +40,17 @@ class LaposteDecoder(Decoder):
                     "type": "pdf"
                 })
 
-            if rep.find('pdfUrl'):
+            if rep.get('pdfUrl'):
                 annexes.append({
                     "name": "label",
-                    "data": rep.find('pdfUrl'),
+                    "data": rep.get('pdfUrl'),
                     "type": "url"
                 })
-
+            
             return {
                 "tracking": {
-                    "number": rep.parcelNumber,
-                    "partner": rep.find('parcelNumberPartner'),
+                    "number": rep.get('parcelNumber'),
+                    "partner": rep.get('parcelNumberPartner'),
                 },
                 "label": {  # main label
                     "name": "label",
@@ -59,7 +59,7 @@ class LaposteDecoder(Decoder):
                 },
                 "parcels": [{
                     "id": 1,
-                    "number": rep.parcelNumber,
+                    "number": rep.get('parcelNumber'),
                     "reference": "",
                     "label": {  # same as main label
                         "name": "label_1",

--- a/roulier/ws_tools.py
+++ b/roulier/ws_tools.py
@@ -127,7 +127,7 @@ def png_to_zpl(png, rotate):
 
 
 def objectified_to_base_types(obj):
-    # handle only ObjectifiedElement from lxml 
+    # handle only ObjectifiedElement from lxml
     # or multi-value structure that may contain ObjectifiedElements
     if not isinstance(obj, (list, tuple, set, dict, ObjectifiedElement)):
         return obj
@@ -151,7 +151,7 @@ def objectified_to_base_types(obj):
                 children_dict = [children_dict[c.tag], objectified_to_base_types(c)]
             else:
                 children_dict[c.tag] = objectified_to_base_types(c)
-            
+
         return children_dict
     if isinstance(obj, list):
         return [objectified_to_base_types(o) for o in obj]

--- a/roulier/ws_tools.py
+++ b/roulier/ws_tools.py
@@ -116,3 +116,14 @@ def png_to_zpl(png, rotate):
         grf = get_grf(png_stream, rotate)
         zpl = build_gfa(grf)
     return zpl
+
+def sanitize_to_string(value):
+    if isinstance(value, dict):
+        value = {sanitize_to_string(k):sanitize_to_string(v) for k, v in value.iteritems()}
+    elif isinstance(value, list):
+        value = [sanitize_to_string(v) for v in value]
+    elif value.__str__:
+        value = value.__str__()
+    else:
+        value = value.__class__.__name__ + " object"
+    return value


### PR DESCRIPTION
Hello, I've been using Roulier recently to communicate with LaPoste carrier webservice but i had some troubles with the lxml format of the data received. I was able to take care of it in my application but I think it would be good for Roulier to return it itself.
So i propose a little fix to convert lxml data types into basic python types.