### PR TITLE
Add get_packing_slip method for laposte

### DIFF
--- a/roulier/api.py
+++ b/roulier/api.py
@@ -67,12 +67,7 @@ class MyValidator(Validator):
         return sanitized
 
 
-class ApiParcel(object):
-    """Define expected fields of carriers.
-
-    This class should be overriden by each carrier.
-    """
-
+class BaseApi(object):
     def __init__(self, config_object):
         self.config = config_object
 
@@ -82,92 +77,11 @@ class ApiParcel(object):
         # v.purge_unknown = True
         return v
 
-    def _address(self):
-        return {
-            "company": {"type": "string", "default": ""},
-            "name": {"type": "string", "default": "", "required": True, "empty": False},
-            "street1": {"type": "string", "default": ""},
-            "street2": {"type": "string", "default": ""},
-            "country": {"type": "string", "default": ""},
-            # , 'description': 'ISO 3166-1 alpha-2 '},
-            "city": {"type": "string", "default": ""},
-            "zip": {"type": "string", "default": ""},
-            "phone": {"type": "string", "default": ""},
-            "email": {"type": "string", "default": ""},
-        }
-
-    def _from_address(self):
-        address = self._address()
-        return address
-
-    def _to_address(self):
-        address = self._address()
-        address["street1"].update({"required": True, "empty": False})
-        address["country"].update({"required": True, "empty": False})
-        address["city"].update({"required": True, "empty": False})
-        address["zip"].update({"required": True, "empty": False})
-        return address
-
-    def _parcel(self):
-        return {
-            "weight": {
-                "type": "float",
-                "default": "",
-                "required": True,
-                "empty": False,
-            },
-            # reference of parcel in external app
-            # This ref should be attached to the label in roulier response so the
-            # external app is able to link a label file/tracking ref to the corresponding
-            # parcel.
-            "reference": {"type": "string"},
-        }
-        # 'description': 'Weight in kg',
-
-    def _parcels(self):
-        v = MyValidator()
-        return {
-            "type": "list",
-            "schema": {"schema": self._parcel(), "type": "dict"},
-        }
-
-    def _service(self):
-        return {
-            "product": {"default": ""},
-            "agencyId": {"default": ""},
-            "customerId": {"default": ""},
-            "shippingId": {"default": ""},
-            # 'description': 'When the carrier has the package. Format: YYYY/MM/DD'
-            "shippingDate": {
-                "default": "",
-                "type": "string",
-                "required": True,
-                "empty": False,
-            },
-            # 'description': 'Additionnal info visible by the client. Example : order number'
-            "reference1": {"type": "string", "default": ""},
-            "reference2": {"type": "string", "default": ""},
-            "reference3": {"type": "string", "default": ""},
-            # 'description': 'Format of output (usually pdf or zpl)'
-            "labelFormat": {"default": ""},
-            # 'description': 'Additionnal instructions for delivery',
-            "instructions": {"default": ""},
-        }
-
     def _auth(self):
         return {
             "login": {"type": "string", "default": ""},
             "password": {"type": "string", "default": ""},
             "isTest": {"type": "boolean", "default": False},
-        }
-
-    def _schemas(self):
-        return {
-            "service": self._service(),
-            "auth": self._auth(),
-            "parcels": self._parcels(),
-            "from_address": self._from_address(),
-            "to_address": self._to_address(),
         }
 
     def api_schema(self):
@@ -226,3 +140,124 @@ class ApiParcel(object):
         See http://docs.python-cerberus.org/en/stable/usage.html
         """
         return self._validator().normalized(data, self.api_schema())
+
+
+class ApiParcel(BaseApi):
+    """Define expected fields of carriers.
+
+    This class should be overriden by each carrier.
+    """
+
+    def _address(self):
+        return {
+            "company": {"type": "string", "default": ""},
+            "name": {"type": "string", "default": "", "required": True, "empty": False},
+            "street1": {"type": "string", "default": ""},
+            "street2": {"type": "string", "default": ""},
+            "country": {"type": "string", "default": ""},
+            # , 'description': 'ISO 3166-1 alpha-2 '},
+            "city": {"type": "string", "default": ""},
+            "zip": {"type": "string", "default": ""},
+            "phone": {"type": "string", "default": ""},
+            "email": {"type": "string", "default": ""},
+        }
+
+    def _from_address(self):
+        address = self._address()
+        return address
+
+    def _to_address(self):
+        address = self._address()
+        address["street1"].update({"required": True, "empty": False})
+        address["country"].update({"required": True, "empty": False})
+        address["city"].update({"required": True, "empty": False})
+        address["zip"].update({"required": True, "empty": False})
+        return address
+
+    def _parcel(self):
+        return {
+            "weight": {
+                "type": "float",
+                "default": "",
+                "required": True,
+                "empty": False,
+            },
+            # reference of parcel in external app
+            # This ref should be attached to the label in roulier response so the
+            # external app is able to link a label file/tracking ref to the corresponding
+            # parcel.
+            "reference": {"type": "string"},
+        }
+        # 'description': 'Weight in kg',
+
+    def _parcels(self):
+        return {
+            "type": "list",
+            "schema": {"schema": self._parcel(), "type": "dict"},
+        }
+
+    def _service(self):
+        return {
+            "product": {"default": ""},
+            "agencyId": {"default": ""},
+            "customerId": {"default": ""},
+            "shippingId": {"default": ""},
+            # 'description': 'When the carrier has the package. Format: YYYY/MM/DD'
+            "shippingDate": {
+                "default": "",
+                "type": "string",
+                "required": True,
+                "empty": False,
+            },
+            # 'description': 'Additionnal info visible by the client. Example : order number'
+            "reference1": {"type": "string", "default": ""},
+            "reference2": {"type": "string", "default": ""},
+            "reference3": {"type": "string", "default": ""},
+            # 'description': 'Format of output (usually pdf or zpl)'
+            "labelFormat": {"default": ""},
+            # 'description': 'Additionnal instructions for delivery',
+            "instructions": {"default": ""},
+        }
+
+    def _schemas(self):
+        return {
+            "service": self._service(),
+            "auth": self._auth(),
+            "parcels": self._parcels(),
+            "from_address": self._from_address(),
+            "to_address": self._to_address(),
+        }
+
+
+class ApiPackingSlip(BaseApi):
+    def _packing_slip_number(self):
+        return {
+            "schema": {"type": "string", "empty": False,},
+            "required": True,
+            "excludes": "parcels_numbers",
+        }
+
+    def _parcels_numbers(self):
+        return {
+            "type": "list",
+            "schema": {"type": "string", "empty": False,},
+            "empty": False,
+            "required": True,
+            "excludes": "packing_slip_number",
+        }
+
+    def _schemas(self):
+        return {
+            "packing_slip_number": self._packing_slip_number(),
+            "parcels_numbers": self._parcels_numbers(),
+            "auth": self._auth(),
+        }
+
+    def validate(self, data):
+        """Ensure the data are valid.
+
+        returns: bool
+
+        See also errors()
+        """
+        return self._validator().validate(data, self.api_schema())

--- a/roulier/api.py
+++ b/roulier/api.py
@@ -252,12 +252,3 @@ class ApiPackingSlip(BaseApi):
             "parcels_numbers": self._parcels_numbers(),
             "auth": self._auth(),
         }
-
-    def validate(self, data):
-        """Ensure the data are valid.
-
-        returns: bool
-
-        See also errors()
-        """
-        return self._validator().validate(data, self.api_schema())

--- a/roulier/carrier_action.py
+++ b/roulier/carrier_action.py
@@ -69,3 +69,29 @@ class CarrierGetLabel(Carrier, ABC):
                 response = transport.send(payload)
                 decoder.decode(response, payload)
         return decoder.result
+
+
+class CarrierGetPackingSlip(Carrier, ABC):
+    """
+    Manages the "packing slip" to give to the carrier who should sign it before taking
+    the packages he will deliver
+    """
+
+    is_test = False
+    roulier_input = None
+
+    def get_packing_slip(self, carrier_type, action, data):
+        """
+        Retrieves the packing slip if the webservice handles it.
+        If the webservice does not handle packing slip, we can generate out own printable html
+        packing slip to give to the carrier.
+        """
+        encoder = self.encoder(self)
+        decoder = self.decoder(self)
+        transport = self.transport(self)
+        self.roulier_input = data
+
+        payload = encoder.encode(data)
+        response = transport.send(payload)
+        decoder.decode(response, payload)
+        return decoder.result

--- a/roulier/carriers/laposte_fr/api.py
+++ b/roulier/carriers/laposte_fr/api.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Implementation of Laposte Api."""
+from roulier.api import ApiPackingSlip
 from roulier.api import ApiParcel
 
 LAPOSTE_LABEL_FORMAT = (
@@ -192,3 +193,11 @@ class LaposteFrApiParcel(ApiParcel):
     def _schemas(self):
         schemas = super()._schemas()
         return schemas
+
+
+class LaposteFrApiPackingSlip(ApiPackingSlip):
+    def _auth(self):
+        schema = super()._auth()
+        schema["login"].update({"required": True, "empty": False})
+        schema["password"]["required"] = False
+        return schema

--- a/roulier/carriers/laposte_fr/carrier_action.py
+++ b/roulier/carriers/laposte_fr/carrier_action.py
@@ -1,9 +1,13 @@
 """Implementation for Laposte."""
 from ...carrier_action import CarrierGetLabel
+from ...carrier_action import CarrierGetPackingSlip
 from ...roulier import factory
 from .encoder import LaposteFrEncoder
+from .encoder import LaposteFrEncoderGetPackingSlip
 from .decoder import LaposteFrDecoderGetLabel
+from .decoder import LaposteFrDecoderGetPackingSlip
 from .transport import LaposteFrTransport
+from .api import LaposteFrApiPackingSlip
 from .api import LaposteFrApiParcel
 
 
@@ -18,4 +22,16 @@ class LaposteFrGetabel(CarrierGetLabel):
     manage_multi_label = False
 
 
+class LaposteFrGetPackingSlip(CarrierGetPackingSlip):
+    """Implementation for Laposte."""
+
+    ws_url = "https://ws.colissimo.fr/sls-ws/SlsServiceWS"
+    encoder = LaposteFrEncoderGetPackingSlip
+    decoder = LaposteFrDecoderGetPackingSlip
+    transport = LaposteFrTransport
+    api = LaposteFrApiPackingSlip
+    manage_multi_slip = False
+
+
 factory.register_builder("laposte_fr", "get_label", LaposteFrGetabel)
+factory.register_builder("laposte_fr", "get_packing_slip", LaposteFrGetPackingSlip)

--- a/roulier/carriers/laposte_fr/decoder.py
+++ b/roulier/carriers/laposte_fr/decoder.py
@@ -70,7 +70,7 @@ class LaposteFrDecoderGetLabel(DecoderGetLabel):
                 # and cerberus won't accept an ElementString insteadof a string.
                 "number": _get_text(rep, "parcelNumber"),
                 "url": "",
-                "partner": _get_text(rep, "parcelNumberPartner"),
+                "partner": _get_text(rep, "parcelNumberPartner", ""),
             },
             "label": {
                 "data": base64.b64encode(parts.get(label_cid)),
@@ -122,7 +122,7 @@ class LaposteFrDecoderGetPackingSlip(DecoderGetPackingSlip):
             self.result["annexes"].append(
                 {
                     "name": "packing_slip",
-                    "data": parts.get(packing_slip_cid),
+                    "data": base64.b64encode(parts.get(packing_slip_cid)),
                     "type": "pdf",
                 }
             )

--- a/roulier/carriers/laposte_fr/decoder.py
+++ b/roulier/carriers/laposte_fr/decoder.py
@@ -1,9 +1,38 @@
 # -*- coding: utf-8 -*-
 """Laposte XML -> Python."""
+from datetime import datetime
 from lxml import objectify
 
 from ...codec import DecoderGetLabel
+from ...codec import DecoderGetPackingSlip
 import base64
+
+
+class _UNSPECIFIED:
+    pass
+
+
+def _get_text(xml, tag, default=_UNSPECIFIED):
+    """
+    Returns the text content of a tag to avoid returning an lxml instance
+    If no default is specified, it will raises the original exception of accessing
+    to an inexistant tag
+    """
+    if not hasattr(xml, tag):
+        if default is _UNSPECIFIED:
+            # raise classic attr error
+            return getattr(xml, tag)
+        return default
+    return getattr(xml, tag).text
+
+
+def _get_cid(tag, tree):
+    element = tree.find(tag)
+    if element is None:
+        return None
+    href = element.getchildren()[0].attrib["href"]
+    # href contains cid:236212...-38932@cfx.apache.org
+    return href[len("cid:") :]  # remove prefix
 
 
 class LaposteFrDecoderGetLabel(DecoderGetLabel):
@@ -18,17 +47,9 @@ class LaposteFrDecoderGetLabel(DecoderGetLabel):
         xml = objectify.fromstring(body)
         msg = xml.xpath("//return")[0]
 
-        def get_cid(tag, tree):
-            element = tree.find(tag)
-            if element is None:
-                return None
-            href = element.getchildren()[0].attrib["href"]
-            # href contains cid:236212...-38932@cfx.apache.org
-            return href[len("cid:") :]  # remove prefix
-
         rep = msg.labelResponse
-        cn23_cid = get_cid("cn23", rep)
-        label_cid = get_cid("label", rep)
+        cn23_cid = _get_cid("cn23", rep)
+        label_cid = _get_cid("label", rep)
 
         annexes = []
 
@@ -45,9 +66,11 @@ class LaposteFrDecoderGetLabel(DecoderGetLabel):
             "id": 1,  # no multi parcel management for now.
             "reference": self._get_parcel_number(input_payload),
             "tracking": {
-                "number": rep.parcelNumber,
+                # we need to force to real string because of those data can be reused
+                # and cerberus won't accept an ElementString insteadof a string.
+                "number": _get_text(rep, "parcelNumber"),
                 "url": "",
-                "partner": rep.find("parcelNumberPartner"),
+                "partner": _get_text(rep, "parcelNumberPartner"),
             },
             "label": {
                 "data": base64.b64encode(parts.get(label_cid)),
@@ -57,3 +80,50 @@ class LaposteFrDecoderGetLabel(DecoderGetLabel):
         }
         self.result["parcels"].append(parcel)
         self.result["annexes"] += annexes
+
+
+class LaposteFrDecoderGetPackingSlip(DecoderGetPackingSlip):
+    """Laposte Bordereau Response XML -> Python."""
+
+    def decode(self, response, input_payload):
+        body = response["body"]
+        parts = response["parts"]
+        xml = objectify.fromstring(body)
+        msg = xml.xpath("//return")[0]
+        header = msg.bordereau.bordereauHeader
+        published_dt = _get_text(header, "publishingDate", None)
+        if published_dt:
+            if "." in published_dt:
+                # get packing slip with it's number does not return microseconds
+                # but when creating a new one, it does... We remove microseconds in result
+                # to have a better homogeneity
+                published_dt = published_dt.split(".")
+                published_dt = "%s+%s" % (
+                    published_dt[0],
+                    published_dt[1].split("+")[1],
+                )
+            published_datetime = datetime.strptime(published_dt, "%Y-%m-%dT%H:%M:%S%z")
+        self.result["packing_slip"] = {
+            "number": _get_text(header, "bordereauNumber", None),
+            "published_datetime": published_datetime,
+            "number_of_parcels": int(_get_text(header, "numberOfParcels", 0)),
+            "site_pch": {
+                "code": _get_text(header, "codeSitePCH", None),
+                "name": _get_text(header, "nameSitePCH", None),
+            },
+            "client": {
+                "number": _get_text(header, "clientNumber", None),
+                "adress": _get_text(header, "Address", None),
+                "company": _get_text(header, "Company", None),
+            },
+        }
+        packing_slip_cid = _get_cid("bordereauDataHandler", msg.bordereau)
+        if packing_slip_cid:
+            self.result["annexes"].append(
+                {
+                    "name": "packing_slip",
+                    "data": parts.get(packing_slip_cid),
+                    "type": "pdf",
+                }
+            )
+        return self.result

--- a/roulier/carriers/laposte_fr/templates/laposte_generateBordereauByParcelsNumbers.xml
+++ b/roulier/carriers/laposte_fr/templates/laposte_generateBordereauByParcelsNumbers.xml
@@ -1,0 +1,9 @@
+<sls:generateBordereauByParcelsNumbers xmlns:sls="http://sls.ws.coliposte.fr">
+    <contractNumber>{{ auth.login }}</contractNumber>
+    <password>{{ auth.password }}</password>
+    <generateBordereauParcelNumberList>
+    {% for parcel_number in parcels_numbers %}
+        <parcelsNumbers>{{ parcel_number }}</parcelsNumbers>
+    {% endfor %}
+    </generateBordereauParcelNumberList>
+</sls:generateBordereauByParcelsNumbers>

--- a/roulier/carriers/laposte_fr/templates/laposte_getBordereauByNumber.xml
+++ b/roulier/carriers/laposte_fr/templates/laposte_getBordereauByNumber.xml
@@ -1,0 +1,5 @@
+<sls:getBordereauByNumber xmlns:sls="http://sls.ws.coliposte.fr">
+    <contractNumber>{{ auth.login }}</contractNumber>
+    <password>{{ auth.password }}</password>
+    <bordereauNumber>{{ packing_slip_number }}</bordereauNumber>
+</sls:getBordereauByNumber>

--- a/roulier/carriers/laposte_fr/templates/laposte_get_packing_slip.xml
+++ b/roulier/carriers/laposte_fr/templates/laposte_get_packing_slip.xml
@@ -1,0 +1,1 @@
+{% include 'laposte_getBordereauByNumber.xml' if packing_slip_number else 'laposte_generateBordereauByParcelsNumbers.xml' %}

--- a/roulier/carriers/laposte_fr/tests/data.py
+++ b/roulier/carriers/laposte_fr/tests/data.py
@@ -41,3 +41,11 @@ DATA = {
         "zip": "75001",
     },
 }
+
+PACKING_SLIP_DATA = {
+    "auth": {
+        "login": credentials["login"],
+        "password": credentials["password"],
+        "isTest'": credentials["isTest"],
+    },
+}

--- a/roulier/carriers/laposte_fr/tests/test_laposte_basic.py
+++ b/roulier/carriers/laposte_fr/tests/test_laposte_basic.py
@@ -9,7 +9,7 @@ import pytest
 from roulier import roulier
 from roulier.exception import InvalidApiInput, CarrierError
 
-from .data import DATA
+from .data import DATA, PACKING_SLIP_DATA
 
 logger = logging.getLogger(__name__)
 
@@ -23,8 +23,9 @@ def test_methods():
         "laposte_fr" in roulier.get_carriers_action_available().keys()
     ), "Laposte carrier unavailable"
     assert roulier.get_carriers_action_available()["laposte_fr"] == [
-        "get_label"
-    ], "get_label() method unavailable"
+        "get_label",
+        "get_packing_slip",
+    ], "get_label() or get_packing_slip() methods unavailable"
 
 
 def test_label_basic_checks():
@@ -35,7 +36,7 @@ def test_label_basic_checks():
     vals = copy.deepcopy(DATA)
 
     vals["service"]["product"] = "whatisitproduct"
-    with pytest.raises(CarrierError, match="Le code produit est incorrect"):
+    with pytest.raises(CarrierError, match="'id': 30109"):
         roulier.get("laposte_fr", "get_label", vals)
 
     vals["service"]["product"] = "COL"
@@ -83,6 +84,64 @@ def test_auth():
     vals["service"]["product"] = "COL"
     with pytest.raises(CarrierError, match="Identifiant ou mot de passe incorrect"):
         roulier.get("laposte_fr", "get_label", vals)
+
+
+def test_packing_slip_basic_checks():
+    if _do_not_execute_test_on_remote():
+        return
+    vals = copy.deepcopy(PACKING_SLIP_DATA)
+    regex = r".*((packing_slip_number|parcels_numbers)': \['required field'.*){2}"
+    with pytest.raises(InvalidApiInput, match=regex):
+        roulier.get("laposte_fr", "get_packing_slip", vals)
+
+    vals["parcels_numbers"] = ["123", "456"]
+    vals["packing_slip_number"] = "123"
+    regex = r"'parcels_numbers' must not be present with 'packing_slip_number'"
+    with pytest.raises(InvalidApiInput, match=regex):
+        roulier.get("laposte_fr", "get_packing_slip", vals)
+
+
+def test_common_failed_get_packing_slip():
+    if _do_not_execute_test_on_remote():
+        return
+    vals = copy.deepcopy(PACKING_SLIP_DATA)
+
+    vals["parcels_numbers"] = ["123", "456"]
+    regex = r"'id': 50031"  # numéro de colis invalide
+    with pytest.raises(CarrierError, match=regex):
+        roulier.get("laposte_fr", "get_packing_slip", vals)
+
+    del vals["parcels_numbers"]
+    vals["packing_slip_number"] = "0"
+    regex = r"'id': 50027"  # not found
+    with pytest.raises(CarrierError, match=regex):
+        roulier.get("laposte_fr", "get_packing_slip", vals)
+
+
+def test_common_success_get_packing_slip():
+    if _do_not_execute_test_on_remote():
+        return
+    # first, we need to create a valid parcel number
+    vals = copy.deepcopy(DATA)
+    vals["service"]["product"] = "COL"
+    vals["parcels"][0]["nonMachinable"] = True
+    result = roulier.get("laposte_fr", "get_label", vals)
+
+    # now we can get the packing slip for this parcel
+    vals = copy.deepcopy(PACKING_SLIP_DATA)
+    vals["parcels_numbers"] = [p["tracking"]["number"] for p in result["parcels"]]
+    res = roulier.get("laposte_fr", "get_packing_slip", vals)
+
+    assert res["packing_slip"].get("number")
+    assert res["packing_slip"].get("number_of_parcels") == len(vals["parcels_numbers"])
+
+    # now we can get the packing slip with it's ID
+    vals = copy.deepcopy(PACKING_SLIP_DATA)
+    vals["packing_slip_number"] = res["packing_slip"]["number"]
+    new_res = roulier.get("laposte_fr", "get_packing_slip", vals)
+
+    # we sould get the same result: it's not a newly generated document.
+    assert res == new_res
 
 
 def _do_not_execute_test_on_remote():

--- a/roulier/codec.py
+++ b/roulier/codec.py
@@ -1,8 +1,8 @@
 """Transform to/from a carrier specific format."""
-from abc import ABC, abstractmethod
-from .exception import InvalidApiInput
-from .api import ApiParcel
 import logging
+from abc import ABC, abstractmethod
+
+from .exception import InvalidApiInput
 
 _logger = logging.getLogger(__name__)
 
@@ -79,3 +79,36 @@ class DecoderGetLabel(ABC):
         if len(parcels) == 1:
             parcel_ref = parcels[0].get("reference", "")
         return parcel_ref
+
+
+class DecoderGetPackingSlip(ABC):
+    def __init__(self, config_object):
+        """
+        packing_slip should be a dict of this form
+        {
+            "number": "string" or None,
+            "published_datetime": aware_datetime or None,
+            "number_of_parcels": int or None,
+            "client": {
+                "number": "string" or None,
+                "adress": "string" or None,
+                "company": "string" or None,
+            }
+        }
+        """
+        self.config = config_object
+        self.result = {
+            "packing_slip": {},
+            "annexes": [],
+        }
+
+    @abstractmethod
+    def decode(self, response, payload):
+        """Transform a specific representation to python dict.
+        Args:
+            response : answer from the webservice
+            payload : data sent initially to the webservice
+        Need to increment the result attribute of the object, it does not need to return
+        anything
+        """
+        pass


### PR DESCRIPTION
Hi !

Here a PR which adds a new functionnaly allowing to get a packing slip file (pdf) from laposte for a list of parcels numbers, or get an existing packing slip via it's number.

* Tests added.
* Some code refactoring to avoid some code duplication
* one existing test fixed which was caused by the change of the message returned by laposte (better to test on IDs to avoid this IMHO)