### PR TITLE
same input format for shippingDate

### DIFF
--- a/roulier/api.py
+++ b/roulier/api.py
@@ -203,12 +203,7 @@ class ApiParcel(BaseApi):
             "customerId": {"default": ""},
             "shippingId": {"default": ""},
             # 'description': 'When the carrier has the package. Format: YYYY/MM/DD'
-            "shippingDate": {
-                "default": "",
-                "type": "string",
-                "required": True,
-                "empty": False,
-            },
+            "shippingDate": {"type": "date", "required": True, "empty": False,},
             # 'description': 'Additionnal info visible by the client. Example : order number'
             "reference1": {"type": "string", "default": ""},
             "reference2": {"type": "string", "default": ""},

--- a/roulier/carriers/chronopost_fr/encoder.py
+++ b/roulier/carriers/chronopost_fr/encoder.py
@@ -4,6 +4,12 @@ from roulier.codec import Encoder
 
 
 class ChronopostFrEncoder(Encoder):
+    def _extra_input_data_processing(self, input_payload, data):
+        data["service"]["shippingDate"] = data["service"]["shippingDate"].strftime(
+            "%Y/%M/%d"
+        )
+        return data
+
     def transform_input_to_carrier_webservice(self, data):
         env = Environment(
             loader=PackageLoader("roulier", "/carriers/chronopost_fr/templates"),

--- a/roulier/carriers/dpd/dpd_encoder.py
+++ b/roulier/carriers/dpd/dpd_encoder.py
@@ -50,9 +50,10 @@ class DpdEncoder(Encoder):
             if data["service"]["notifications"] == "Predict":
                 raise InvalidApiInput("Predict notifications can't be used with Relais")
 
-        data["service"]["shippingDate"] = datetime.strptime(
-            data["service"]["shippingDate"], "%Y/%M/%d"
-        ).strftime("%d/%M/%Y")
+        if data["service"].get("shippingDate"):
+            data["service"]["shippingDate"] = data["service"]["shippingDate"].strftime(
+                "%d/%M/%Y"
+            )
 
         def reduce_address(address):
             """Concat some fields.

--- a/roulier/carriers/geodis/geodis_encoder_ws.py
+++ b/roulier/carriers/geodis/geodis_encoder_ws.py
@@ -51,8 +51,8 @@ class GeodisEncoderWs(Encoder):
             data["service"]["labelFormat"] = self.lookup_label_format(
                 data["service"]["labelFormat"]
             )
-            data["service"]["shippingDate"] = data["service"]["shippingDate"].replace(
-                "/", ""
+            data["service"]["shippingDate"] = data["service"]["shippingDate"].strftime(
+                "%Y%M%d"
             )
             data["from_address"]["departement"] = data["from_address"]["zip"][:2]
             return {

--- a/roulier/carriers/geodis/tests/wip_test_rest.py
+++ b/roulier/carriers/geodis/tests/wip_test_rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from datetime import date
 import json
 from collections import OrderedDict
 
@@ -22,8 +22,8 @@ def test_encode_api():
     encoder = GeodisEncoderRestWs()
     data = encoder.api("trackingList")
 
-    data["service"]["shippingDateStart"] = "2019-07-02"
-    data["service"]["shippingDateEnd"] = "2019-07-02"
+    data["service"]["shippingDateStart"] = date(2019, 7, 2)
+    data["service"]["shippingDateEnd"] = date(2019, 7, 2)
     data["auth"]["login"] = "Akretion"
     data["auth"]["password"] = "121221789271"
 

--- a/roulier/carriers/gls_fr/api.py
+++ b/roulier/carriers/gls_fr/api.py
@@ -20,8 +20,6 @@ class GlsApiParcel(ApiParcel):
         schema["reference1"] = {"maxlength": 20}
         schema["reference2"] = {"maxlength": 20}
         schema["instructions"] = {"maxlength": 35}
-        schema["shippingDate"] = {"required": True}
-        # schema["shippingDate"] = {"date": "%Y%m%d", "required": True}
         schema["consignee_ref"] = {"maxlength": 20}
         schema["parcel_total_number"] = {
             "max": 999,

--- a/roulier/carriers/laposte_fr/encoder.py
+++ b/roulier/carriers/laposte_fr/encoder.py
@@ -46,6 +46,7 @@ class LaposteFrEncoder(LaposteFrEncoderBase):
         data["service"]["labelFormat"] = self.lookup_label_format(
             data["service"]["labelFormat"]
         )
+        data["service"]["shippingDate"] = data["service"]["shippingDate"].isoformat()
         # Since multi parcels is not managed for la poste, some informations are expected
         # in service by laposte but are in parcel in roulier.
         parcel = data["parcels"][0]

--- a/roulier/carriers/laposte_fr/tests/data.py
+++ b/roulier/carriers/laposte_fr/tests/data.py
@@ -22,7 +22,7 @@ DATA = {
         "password": credentials["password"],
         "isTest'": credentials["isTest"],
     },
-    "service": {"shippingDate": date.today().isoformat()},
+    "service": {"shippingDate": date.today()},
     "parcels": [{"weight": 1.2, "instructions": "Fake instructions"}],
     "to_address": {
         "name": "Fr",


### PR DESCRIPTION
As master has multiple backward compatibility breaks, maybe it's the moment fix this. shippingDate has currently multiple (not checked) formats : yyyy/mm/dd seems to be the expected one regarding the comment but if we give it to laposte, it will fail because laposte expect yyyy-mm-dd format.

I think it would be KISSer if we just give a date and each carrier will format it according to its own expected format. 