### PR TITLE
fix missing PDF_A6 format

### DIFF
--- a/roulier/carriers/dpd_fr_soap/api.py
+++ b/roulier/carriers/dpd_fr_soap/api.py
@@ -6,6 +6,7 @@ from roulier.api import MyValidator
 
 DPD_LABEL_FORMAT = (
     "PDF",
+    "PDF_A6",
     "PNG",
     "ZPL",
 )

--- a/roulier/carriers/dpd_fr_soap/tests/test_dpd.py
+++ b/roulier/carriers/dpd_fr_soap/tests/test_dpd.py
@@ -100,6 +100,46 @@ def test_predict():
 
 
 @_test_ip_allowed(True)
+def test_dpd_format_pdf():
+    vals = copy.deepcopy(DATA)
+    vals["service"]["labelFormat"] = "PDF"
+    result = roulier.get("dpd_fr_soap", "get_label", vals)
+    assert_result(vals, result, 1, 1, "PDF")
+
+
+@_test_ip_allowed(True)
+def test_dpd_format_pdf_a6():
+    vals = copy.deepcopy(DATA)
+    vals["service"]["labelFormat"] = "PDF_A6"
+    result = roulier.get("dpd_fr_soap", "get_label", vals)
+    assert_result(vals, result, 1, 1, "PDF_A6")
+
+
+@_test_ip_allowed(True)
+def test_dpd_format_png():
+    vals = copy.deepcopy(DATA)
+    vals["service"]["labelFormat"] = "PNG"
+    result = roulier.get("dpd_fr_soap", "get_label", vals)
+    assert_result(vals, result, 1, 1, "PNG")
+
+
+@_test_ip_allowed(True)
+def test_dpd_format_zpl():
+    vals = copy.deepcopy(DATA)
+    vals["service"]["labelFormat"] = "ZPL"
+    result = roulier.get("dpd_fr_soap", "get_label", vals)
+    assert_result(vals, result, 1, 1, "ZPL")
+
+
+@_test_ip_allowed(True)
+def test_dpd_format_invalid():
+    vals = copy.deepcopy(DATA)
+    vals["service"]["labelFormat"] = "invalid"
+    with assert_raises(InvalidApiInput, {"service": [{"labelFormat": "unallowed"}]}):
+        result = roulier.get("dpd_fr_soap", "get_label", vals)
+
+
+@_test_ip_allowed(True)
 def test_common_failed_get_label():
     vals = copy.deepcopy(DATA)
     # Weight


### PR DESCRIPTION
With a labelFormat = `PDF`, DPD sends a PDF with the label in the correct size (approx A6) but in an A4 PDF.  
DPD can manage an A6 PDF format. This PR adds the support of this format and tests for each supported format.

In the documentation I have (11.9a, october, 2020), they also should support `EPL` and `ZPL300` but DPD returns an error saying it's not supported.
