### PR TITLE
remove useless old py27 # -*- coding: utf-8 -*-

### DIFF
--- a/roulier.py
+++ b/roulier.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 if __name__ == "__main__":
     print("from Cli")

--- a/roulier/__init__.py
+++ b/roulier/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from . import roulier
 from . import exception
 from . import api

--- a/roulier/carriers/dpd_fr_soap/api.py
+++ b/roulier/carriers/dpd_fr_soap/api.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Implementation of Dpd Api."""
 
 from roulier.api import ApiParcel

--- a/roulier/carriers/dpd_fr_soap/api.py
+++ b/roulier/carriers/dpd_fr_soap/api.py
@@ -1,4 +1,3 @@
-
 """Implementation of Dpd Api."""
 
 from roulier.api import ApiParcel

--- a/roulier/carriers/dpd_fr_soap/tests/test_dpd.py
+++ b/roulier/carriers/dpd_fr_soap/tests/test_dpd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import copy
 import re

--- a/roulier/carriers/geodis/__init__.py
+++ b/roulier/carriers/geodis/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from . import geodis
 from . import geodis_common_ws
 from . import geodis_api_ws

--- a/roulier/carriers/geodis/geodis.py
+++ b/roulier/carriers/geodis/geodis.py
@@ -1,4 +1,3 @@
-
 """Implementation for Geodis."""
 
 from .geodis_encoder_edi import GeodisEncoderEdi

--- a/roulier/carriers/geodis/geodis.py
+++ b/roulier/carriers/geodis/geodis.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Implementation for Geodis."""
 
 from .geodis_encoder_edi import GeodisEncoderEdi

--- a/roulier/carriers/geodis/geodis_api_edi.py
+++ b/roulier/carriers/geodis/geodis_api_edi.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Implementation of Geodis Api."""
 from roulier.api import Api, MyValidator
 from .geodis_api_ws import GeodisApiWs, GEODIS_ALLOWED_NOTIFICATIONS

--- a/roulier/carriers/geodis/geodis_api_edi.py
+++ b/roulier/carriers/geodis/geodis_api_edi.py
@@ -1,4 +1,3 @@
-
 """Implementation of Geodis Api."""
 from roulier.api import Api, MyValidator
 from .geodis_api_ws import GeodisApiWs, GEODIS_ALLOWED_NOTIFICATIONS

--- a/roulier/carriers/geodis/geodis_api_find_localite_ws.py
+++ b/roulier/carriers/geodis/geodis_api_find_localite_ws.py
@@ -1,4 +1,3 @@
-
 """Implementation of Geodis Ws Api."""
 from roulier.api import Api
 

--- a/roulier/carriers/geodis/geodis_api_find_localite_ws.py
+++ b/roulier/carriers/geodis/geodis_api_find_localite_ws.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Implementation of Geodis Ws Api."""
 from roulier.api import Api
 

--- a/roulier/carriers/geodis/geodis_api_rest_ws.py
+++ b/roulier/carriers/geodis/geodis_api_rest_ws.py
@@ -1,4 +1,3 @@
-
 """Implementation of Geodis Api."""
 from roulier.api import Api
 

--- a/roulier/carriers/geodis/geodis_api_rest_ws.py
+++ b/roulier/carriers/geodis/geodis_api_rest_ws.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Implementation of Geodis Api."""
 from roulier.api import Api
 

--- a/roulier/carriers/geodis/geodis_api_ws.py
+++ b/roulier/carriers/geodis/geodis_api_ws.py
@@ -1,4 +1,3 @@
-
 """Implementation of Geodis Ws Api."""
 from roulier.api import Api
 

--- a/roulier/carriers/geodis/geodis_api_ws.py
+++ b/roulier/carriers/geodis/geodis_api_ws.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Implementation of Geodis Ws Api."""
 from roulier.api import Api
 

--- a/roulier/carriers/geodis/geodis_common_ws.py
+++ b/roulier/carriers/geodis/geodis_common_ws.py
@@ -1,4 +1,3 @@
-
 """Store infos about ws"""
 from .geodis_api_ws import GeodisApiWs
 from .geodis_api_rest_ws import (

--- a/roulier/carriers/geodis/geodis_common_ws.py
+++ b/roulier/carriers/geodis/geodis_common_ws.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Store infos about ws"""
 from .geodis_api_ws import GeodisApiWs
 from .geodis_api_rest_ws import (

--- a/roulier/carriers/geodis/geodis_decoder_rest_ws.py
+++ b/roulier/carriers/geodis/geodis_decoder_rest_ws.py
@@ -1,4 +1,3 @@
-
 """Geodis XML -> Python."""
 from roulier.codec import Decoder
 from .geodis_api_rest_ws import GeodisApiTrackingListOut

--- a/roulier/carriers/geodis/geodis_decoder_rest_ws.py
+++ b/roulier/carriers/geodis/geodis_decoder_rest_ws.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Geodis XML -> Python."""
 from roulier.codec import Decoder
 from .geodis_api_rest_ws import GeodisApiTrackingListOut

--- a/roulier/carriers/geodis/geodis_decoder_ws.py
+++ b/roulier/carriers/geodis/geodis_decoder_ws.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Geodis XML -> Python."""
 from roulier.codec import Decoder
 from .geodis_common_ws import GEODIS_INFOS

--- a/roulier/carriers/geodis/geodis_decoder_ws.py
+++ b/roulier/carriers/geodis/geodis_decoder_ws.py
@@ -1,4 +1,3 @@
-
 """Geodis XML -> Python."""
 from roulier.codec import Decoder
 from .geodis_common_ws import GEODIS_INFOS

--- a/roulier/carriers/geodis/geodis_encoder_edi.py
+++ b/roulier/carriers/geodis/geodis_encoder_edi.py
@@ -1,4 +1,3 @@
-
 """Implementation of Geodis Api."""
 from datetime import datetime
 from roulier.codec import Encoder

--- a/roulier/carriers/geodis/geodis_encoder_edi.py
+++ b/roulier/carriers/geodis/geodis_encoder_edi.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Implementation of Geodis Api."""
 from datetime import datetime
 from roulier.codec import Encoder

--- a/roulier/carriers/geodis/geodis_encoder_rest_ws.py
+++ b/roulier/carriers/geodis/geodis_encoder_rest_ws.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Implementation of Geodis Api."""
 from roulier.codec import Encoder
 from roulier.exception import InvalidApiInput

--- a/roulier/carriers/geodis/geodis_encoder_rest_ws.py
+++ b/roulier/carriers/geodis/geodis_encoder_rest_ws.py
@@ -1,4 +1,3 @@
-
 """Implementation of Geodis Api."""
 from roulier.codec import Encoder
 from roulier.exception import InvalidApiInput

--- a/roulier/carriers/geodis/geodis_encoder_ws.py
+++ b/roulier/carriers/geodis/geodis_encoder_ws.py
@@ -1,4 +1,3 @@
-
 """Transform input to geodis compatible xml."""
 from jinja2 import Environment, PackageLoader
 from roulier.codec import Encoder

--- a/roulier/carriers/geodis/geodis_encoder_ws.py
+++ b/roulier/carriers/geodis/geodis_encoder_ws.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Transform input to geodis compatible xml."""
 from jinja2 import Environment, PackageLoader
 from roulier.codec import Encoder

--- a/roulier/carriers/geodis/geodis_transport_edi.py
+++ b/roulier/carriers/geodis/geodis_transport_edi.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Implement geodisWS."""
 from roulier.transport import Transport
 from datetime import datetime

--- a/roulier/carriers/geodis/geodis_transport_edi.py
+++ b/roulier/carriers/geodis/geodis_transport_edi.py
@@ -1,4 +1,3 @@
-
 """Implement geodisWS."""
 from roulier.transport import Transport
 from datetime import datetime

--- a/roulier/carriers/geodis/geodis_transport_rest_ws.py
+++ b/roulier/carriers/geodis/geodis_transport_rest_ws.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Implement geodisWS."""
 import requests
 

--- a/roulier/carriers/geodis/geodis_transport_rest_ws.py
+++ b/roulier/carriers/geodis/geodis_transport_rest_ws.py
@@ -1,4 +1,3 @@
-
 """Implement geodisWS."""
 import requests
 

--- a/roulier/carriers/geodis/geodis_transport_ws.py
+++ b/roulier/carriers/geodis/geodis_transport_ws.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Implement geodisWS."""
 import requests
 from lxml import objectify

--- a/roulier/carriers/geodis/geodis_transport_ws.py
+++ b/roulier/carriers/geodis/geodis_transport_ws.py
@@ -1,4 +1,3 @@
-
 """Implement geodisWS."""
 import requests
 from lxml import objectify

--- a/roulier/carriers/geodis/tests/wip_test_rest.py
+++ b/roulier/carriers/geodis/tests/wip_test_rest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from datetime import date
 import json
 from collections import OrderedDict

--- a/roulier/carriers/gls_fr/rest/api.py
+++ b/roulier/carriers/gls_fr/rest/api.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Implementation of Laposte Api."""
 
 from roulier.api import ApiParcel

--- a/roulier/carriers/gls_fr/rest/api.py
+++ b/roulier/carriers/gls_fr/rest/api.py
@@ -1,4 +1,3 @@
-
 """Implementation of Laposte Api."""
 
 from roulier.api import ApiParcel

--- a/roulier/carriers/gls_fr/rest/decoder.py
+++ b/roulier/carriers/gls_fr/rest/decoder.py
@@ -1,4 +1,3 @@
-
 """Laposte XML -> Python."""
 
 import base64

--- a/roulier/carriers/gls_fr/rest/decoder.py
+++ b/roulier/carriers/gls_fr/rest/decoder.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Laposte XML -> Python."""
 
 import base64

--- a/roulier/carriers/gls_fr/rest/encoder.py
+++ b/roulier/carriers/gls_fr/rest/encoder.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Transform input to laposte compatible xml."""
 
 from jinja2 import Environment, PackageLoader

--- a/roulier/carriers/gls_fr/rest/encoder.py
+++ b/roulier/carriers/gls_fr/rest/encoder.py
@@ -1,4 +1,3 @@
-
 """Transform input to laposte compatible xml."""
 
 from jinja2 import Environment, PackageLoader

--- a/roulier/carriers/laposte_fr/__init__.py
+++ b/roulier/carriers/laposte_fr/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from . import encoder
 from . import decoder
 from . import transport

--- a/roulier/carriers/laposte_fr/api.py
+++ b/roulier/carriers/laposte_fr/api.py
@@ -1,4 +1,3 @@
-
 """Implementation of Laposte Api."""
 from roulier.api import ApiPackingSlip
 from roulier.api import ApiParcel

--- a/roulier/carriers/laposte_fr/api.py
+++ b/roulier/carriers/laposte_fr/api.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Implementation of Laposte Api."""
 from roulier.api import ApiPackingSlip
 from roulier.api import ApiParcel

--- a/roulier/carriers/laposte_fr/decoder.py
+++ b/roulier/carriers/laposte_fr/decoder.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Laposte XML -> Python."""
 from datetime import datetime
 from lxml import objectify

--- a/roulier/carriers/laposte_fr/decoder.py
+++ b/roulier/carriers/laposte_fr/decoder.py
@@ -1,4 +1,3 @@
-
 """Laposte XML -> Python."""
 from datetime import datetime
 from lxml import objectify

--- a/roulier/carriers/laposte_fr/encoder.py
+++ b/roulier/carriers/laposte_fr/encoder.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Transform input to laposte compatible xml."""
 import logging
 from jinja2 import Environment, PackageLoader

--- a/roulier/carriers/laposte_fr/encoder.py
+++ b/roulier/carriers/laposte_fr/encoder.py
@@ -1,4 +1,3 @@
-
 """Transform input to laposte compatible xml."""
 import logging
 from jinja2 import Environment, PackageLoader

--- a/roulier/carriers/laposte_fr/tests/data.py
+++ b/roulier/carriers/laposte_fr/tests/data.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import logging
 from datetime import date
 

--- a/roulier/carriers/laposte_fr/tests/test_laposte_basic.py
+++ b/roulier/carriers/laposte_fr/tests/test_laposte_basic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import copy
 import base64

--- a/roulier/carriers/laposte_fr/tests/test_laposte_europe.py
+++ b/roulier/carriers/laposte_fr/tests/test_laposte_europe.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import copy
 import pytest

--- a/roulier/carriers/laposte_fr/tests/test_laposte_outside_europe.py
+++ b/roulier/carriers/laposte_fr/tests/test_laposte_outside_europe.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import copy
 

--- a/roulier/carriers/laposte_fr/transport.py
+++ b/roulier/carriers/laposte_fr/transport.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Implement laposteWS."""
 from lxml import objectify, etree
 from jinja2 import Environment, PackageLoader

--- a/roulier/carriers/laposte_fr/transport.py
+++ b/roulier/carriers/laposte_fr/transport.py
@@ -1,4 +1,3 @@
-
 """Implement laposteWS."""
 from lxml import objectify, etree
 from jinja2 import Environment, PackageLoader

--- a/roulier/exception.py
+++ b/roulier/exception.py
@@ -1,4 +1,3 @@
-
 """Exception classes"""
 import logging
 

--- a/roulier/exception.py
+++ b/roulier/exception.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Exception classes"""
 import logging
 

--- a/roulier/transport.py
+++ b/roulier/transport.py
@@ -1,4 +1,3 @@
-
 """Send a request to a carrier and get the result."""
 from abc import ABC, abstractmethod
 import requests

--- a/roulier/transport.py
+++ b/roulier/transport.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Send a request to a carrier and get the result."""
 from abc import ABC, abstractmethod
 import requests

--- a/roulier/ws_tools.py
+++ b/roulier/ws_tools.py
@@ -1,4 +1,3 @@
-
 """Utilities for WS."""
 from lxml import etree
 from jinja2 import Environment, PackageLoader

--- a/roulier/ws_tools.py
+++ b/roulier/ws_tools.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 """Utilities for WS."""
 from lxml import etree
 from jinja2 import Environment, PackageLoader


### PR DESCRIPTION
some cleanup of old python 2.7 comment to set the charset used for files. In py3, charset is utf8 by default.