### PR TITLE
laposte has 2 fields for [home|mobile] phone

### DIFF
--- a/roulier/carriers/laposte_fr/api.py
+++ b/roulier/carriers/laposte_fr/api.py
@@ -160,6 +160,12 @@ class LaposteFrApiParcel(ApiParcel):
             # 'description': 'Needed for cn23'
         }
         schema["customs"] = {"type": "dict", "schema": self._customs()}
+        schema["pickupLocationId"] = {
+            "default": "",
+            # 'description': """Si productCode = A2P, BPR, ACP, CDI, CMT, BDP. "
+            # "Identifiant du point de retrait "
+            # "(dans le cas d’une livraison Colissimo hors domicile)"""
+        }
         return schema
 
     def _auth(self):

--- a/roulier/carriers/laposte_fr/encoder.py
+++ b/roulier/carriers/laposte_fr/encoder.py
@@ -1,4 +1,5 @@
 """Transform input to laposte compatible xml."""
+from copy import deepcopy
 import logging
 from jinja2 import Environment, PackageLoader
 from roulier.exception import InvalidApiInput
@@ -22,6 +23,7 @@ class LaposteFrEncoderBase(Encoder):
         return {}
 
     def transform_input_to_carrier_webservice(self, data):
+        data = deepcopy(data)  # avoid updating user data
         return {
             "body": self._render_template(data),
             "headers": data["auth"],
@@ -32,6 +34,16 @@ class LaposteFrEncoder(LaposteFrEncoderBase):
     """Transform input to laposte compatible xml."""
 
     def _get_template_context(self, data):
+        if data["service"].get("pickupLocationId") and not data["parcels"][0].get(
+            "pickupLocationId"
+        ):
+            data["parcels"][0]["pickupLocationId"] = data["service"].pop(
+                "pickupLocationId"
+            )
+        if data["from_address"].get("commercialName") and not data["service"].get(
+            "companyName"
+        ):
+            data["service"]["commercialName"] = data["from_address"]["companyName"]
         return {
             "service": data["service"],
             "parcel": data["parcels"][0],

--- a/roulier/carriers/laposte_fr/encoder.py
+++ b/roulier/carriers/laposte_fr/encoder.py
@@ -40,8 +40,8 @@ class LaposteFrEncoder(LaposteFrEncoderBase):
             data["parcels"][0]["pickupLocationId"] = data["service"].pop(
                 "pickupLocationId"
             )
-        if data["from_address"].get("commercialName") and not data["service"].get(
-            "companyName"
+        if data["from_address"].get("companyName") and not data["service"].get(
+            "commercialName"
         ):
             data["service"]["commercialName"] = data["from_address"]["companyName"]
         return {

--- a/roulier/carriers/laposte_fr/templates/laposte_address.xml
+++ b/roulier/carriers/laposte_fr/templates/laposte_address.xml
@@ -9,7 +9,17 @@
 	<countryCode>{{ address.country }}</countryCode>
 	<city>{{ address.city }}</city>
 	<zipCode>{{ address.zip }}</zipCode>
-	<mobileNumber>{{ address.phone }}</mobileNumber>
+	{% if address.mobilePhone or address.homeNumber %}
+		{% if address.homeNumber %}
+			<phoneNumber>{{ address.homeNumber }}</phoneNumber>
+		{% endif %}
+		{% if address.mobilePhone %}
+			<mobileNumber>{{ address.mobilePhone }}</mobileNumber>
+		{% endif %}
+	{% else %}
+		{# backward compatibility but should be removed in next major version #}
+		<mobileNumber>{{ address.phone }}</mobileNumber>
+	{% endif %}
 	<doorCode1>{{ address.doorCode1 }}</doorCode1>
 	<doorCode2>{{ address.doorCode2 }}</doorCode2>
 	<email>{{ address.email | default('') }}</email>

--- a/roulier/carriers/laposte_fr/templates/laposte_service.xml
+++ b/roulier/carriers/laposte_fr/templates/laposte_service.xml
@@ -5,6 +5,6 @@
 	<transportationAmount>{{ service.transportationAmount }}</transportationAmount>
 	<totalAmount>{{ service.totalAmount }}</totalAmount>
 	<orderNumber>{{ service.reference1 }}</orderNumber>
-	<commercialName>{{ sender_address.companyName }}</commercialName>
+	<commercialName>{{ service.commercialName }}</commercialName>
 	<returnTypeChoice>{{ service.returnTypeChoice }}</returnTypeChoice>
 </service>


### PR DESCRIPTION
Currently, when a phone is given to the API, it's used as a mobile phone.
With this fix, we can give 2 different numbers avoiding complaints from laposte that a number is not a mobile one.

Backward compatibly is ok.

I also fix some wrong "standard API inputs" (eg pickupId in parcel instead of in service as for other services). Backard compatibility is also ensured : standard one is only used if nothing is set in parcel. Schema has been updated to be specific that parcel can have a pickup id (usefull in case of multiple labels in one api call) 

Tests added.