### PR TITLE
[GLS-REST] Manage company field in roulier api

### DIFF
--- a/roulier/carriers/gls_fr/rest/encoder.py
+++ b/roulier/carriers/gls_fr/rest/encoder.py
@@ -106,6 +106,10 @@ class GlsEuEncoderBase(Encoder):
             addr = data.get(from_addr)
             if not addr:
                 continue
+            # if the company address field is set, then the name is actually the contact
+            if addr["company"] and addr["name"]:
+                addr["contact"] = addr["name"]
+                addr["name"] = addr["company"]
             addresses[to_addr] = dict(
                 (to_field, addr[from_field]) for from_field, to_field in addr_req_fields
             )


### PR DESCRIPTION
All carrier should manage addresses with a company and contact name.

For the gls rest webservice, currently, roulier expects : 
- name with the company name or person name receiver is not a company
- contact in case the receiver is a company.

For most of carriers, roulier expects : 
- company with the company name
- name with the person name it is addressed

The goal of this PR is to make gls consitent with the other carrier.
It does not break anything since I left the contact field. So if one does not use the company field, it does not change anything.

I would like to add a comment to indicates that contact is deprecated so we remove it in an other major version.

Overall, we should work to have a really common api for all carriers in roulier for all basic stuff.
@DylannCordel any comment about this one?