### PR TITLE
[ADD] value for T400 on encoder for gls belgium

### DIFF
--- a/roulier/carriers/gls_fr/glsbox/encoder.py
+++ b/roulier/carriers/gls_fr/glsbox/encoder.py
@@ -51,6 +51,7 @@ PARCEL_MAPPING = {
     "T530": "weight",
     "T8973": "parcel_number_barcode",
     "T8904": "parcel_number_label",
+    "T400": "parcel_sequence",
 }
 
 


### PR DESCRIPTION
The value of the field parcel_sequence is calculated on Odoo module like this:

 vals["parcel_sequence"] = self.calc_parcel_num()


    @api.model
    def _get_sequence(self):
        sequence = self.env["ir.sequence"].next_by_code("delivery_carrier_gls")
        if not sequence:
            raise UserError(_("There is no sequence defined for the label GLS"))
        return sequence

    def calc_parcel_num(self):
        start_num = (
            self.env["ir.config_parameter"]
            .sudo()
            .get_param("PARCEL_NUM_START", 01234567890)
        )
        parcel_num = self._get_sequence()
        num = int(start_num) + int(parcel_num)
        num = str(num)
        num = list(num)
        num.reverse()
        weighting = 3
        sum_of_num = 0
        for item in num:
            sum_of_num += int(item) * weighting
            if weighting == 3:
                weighting = 1
            else:
                weighting = 3
        sum_of_num += 1
        check_num = int(math.ceil(sum_of_num / 10.0)) * 10 - sum_of_num
        num.reverse()
        num.append(str(check_num))
        return "".join(num)