### PR TITLE
[IMP] Add compatibility with newest jinja2 versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-Cerberus==1.1
-jinja2==2.11.3
-.
+jinja2>=3.0.0

--- a/roulier/carriers/chronopost_fr/encoder.py
+++ b/roulier/carriers/chronopost_fr/encoder.py
@@ -13,7 +13,6 @@ class ChronopostFrEncoder(Encoder):
     def transform_input_to_carrier_webservice(self, data):
         env = Environment(
             loader=PackageLoader("roulier", "carriers/chronopost_fr/templates"),
-            extensions=["jinja2.ext.with_", "jinja2.ext.autoescape"],
             autoescape=True,
         )
         action = self.config.action

--- a/roulier/carriers/chronopost_fr/transport.py
+++ b/roulier/carriers/chronopost_fr/transport.py
@@ -17,7 +17,6 @@ class ChronopostFrRequestsTransport(RequestsTransport):
         """Wrap body in a soap:Enveloppe."""
         env = Environment(
             loader=PackageLoader("roulier", "carriers/chronopost_fr/templates"),
-            extensions=["jinja2.ext.with_"],
         )
 
         template = env.get_template("chronopost_soap.xml")

--- a/roulier/carriers/dpd_fr_soap/encoder.py
+++ b/roulier/carriers/dpd_fr_soap/encoder.py
@@ -48,7 +48,6 @@ class DpdEncoder(Encoder):
 
         env = Environment(
             loader=PackageLoader("roulier", "carriers/dpd_fr_soap/templates"),
-            extensions=["jinja2.ext.with_", "jinja2.ext.autoescape"],
             autoescape=True,
         )
 

--- a/roulier/carriers/dpd_fr_soap/transport.py
+++ b/roulier/carriers/dpd_fr_soap/transport.py
@@ -26,7 +26,6 @@ class DpdTransport(RequestsTransport):
         """Wrap body in a soap:Enveloppe."""
         env = Environment(
             loader=PackageLoader("roulier", "carriers/dpd_fr_soap/templates"),
-            extensions=["jinja2.ext.with_"],
         )
 
         template = env.get_template("dpd_soap.xml")

--- a/roulier/carriers/geodis/geodis_encoder_ws.py
+++ b/roulier/carriers/geodis/geodis_encoder_ws.py
@@ -29,7 +29,6 @@ class GeodisEncoderWs(Encoder):
             raise InvalidApiInput("Input error : %s" % api.errors(api_input))
         env = Environment(
             loader=PackageLoader("roulier", "carriers/geodis/templates"),
-            extensions=["jinja2.ext.with_", "jinja2.ext.autoescape"],
             autoescape=True,
         )
         template = env.get_template("geodis_%s.xml" % action)

--- a/roulier/carriers/geodis/geodis_transport_ws.py
+++ b/roulier/carriers/geodis/geodis_transport_ws.py
@@ -39,7 +39,6 @@ class GeodisTransportWs(Transport):
         """Wrap body in a soap:Enveloppe."""
         env = Environment(
             loader=PackageLoader("roulier", "carriers/geodis/templates"),
-            extensions=["jinja2.ext.with_"],
         )
 
         template = env.get_template("geodis_soap.xml")

--- a/roulier/carriers/laposte_fr/encoder.py
+++ b/roulier/carriers/laposte_fr/encoder.py
@@ -16,7 +16,6 @@ class LaposteFrEncoderBase(Encoder):
     def _render_template(self, data):
         env = Environment(
             loader=PackageLoader("roulier", "carriers/laposte_fr/templates"),
-            extensions=["jinja2.ext.with_", "jinja2.ext.autoescape"],
             autoescape=True,
         )
         template = env.get_template("laposte_%s.xml" % self.config.action)

--- a/roulier/carriers/laposte_fr/transport.py
+++ b/roulier/carriers/laposte_fr/transport.py
@@ -24,7 +24,6 @@ class LaposteFrTransport(RequestsTransport):
         """Wrap body in a soap:Enveloppe."""
         env = Environment(
             loader=PackageLoader("roulier", "carriers/laposte_fr/templates"),
-            extensions=["jinja2.ext.with_"],
         )
 
         template = env.get_template("laposte_soap.xml")

--- a/roulier/ws_tools.py
+++ b/roulier/ws_tools.py
@@ -19,7 +19,7 @@ def remove_empty_tags(xml, ouput_as_string=True):
     # pkg_resouces may be an alternative, but we already
     # have Jinja
     env = Environment(
-        loader=PackageLoader("roulier", "templates"), extensions=["jinja2.ext.with_"]
+        loader=PackageLoader("roulier", "templates")
     )
     template = env.get_template("remove_empty_tags.xsl")
     xsl = etree.parse(open(template.filename))


### PR DESCRIPTION
jinja versions was fixed to a really old version, I don't think it is usefull anymore and it complexify implementation with other tools using jinja.
Same as cerberus, I did not meet any issue using an up to date version.
We may add a minimal version if it becomes necessary.