### PR TITLE
[IMP] Use raw string for regex to avoid multiple escaping

### DIFF
--- a/roulier/carriers/laposte_fr/api.py
+++ b/roulier/carriers/laposte_fr/api.py
@@ -314,7 +314,7 @@ class LaposteFrApiParcel(ApiParcel):
                     },
                     "email": {
                         "type": "string",
-                        "regex": "^\\w*@\\w*\.\\w*$",
+                        "regex": r"^\w*@\w*.\w*$",
                         "required": False,
                         "maxlength": 80,
                     },


### PR DESCRIPTION
Also avoid the depreciation warning : invalid escape sequence \.

@hparfr 