### PR TITLE
Remove unused dependency pycountry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
         "cerberus",
         "zplgrf",
         "unidecode",
-        "pycountry",
         # v2
         "pydantic",
         "zeep",


### PR DESCRIPTION
As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the direct dependency `pycountry` is specified as a requirement in the `setup.py` file, when in reality it is never used.

This PR removes it from the configuration files, which helps keeping the dependency list clean.

Hope this is helpful!

Best regards