### PR TITLE
Feat/mondialrelay connect api v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Roadmap / TODO:
 	- Write more tests
 	- generate api documentation
 
+# unreleased
+    - Add Mondial Relay Connect REST api (mondialrelay_connect, get_label)
+
 # 1.1.0 2021-04-02
     - Add GLS rest api
     - Fix GLS glsbox api and manage expedition outside France

--- a/roulier/carriers/__init__.py
+++ b/roulier/carriers/__init__.py
@@ -7,3 +7,4 @@ from . import dpd_fr
 from . import geodis_fr
 from . import mondialrelay
 from . import mondialrelay_fr
+from . import mondialrelay_connect

--- a/roulier/carriers/mondialrelay_connect/README.md
+++ b/roulier/carriers/mondialrelay_connect/README.md
@@ -1,0 +1,84 @@
+# Mondial Relay Connect (`mondialrelay_connect`)
+
+Implementation of the Mondial Relay **Connect** REST API (Web Service Dual
+Carrier) for label creation.
+
+This is distinct from the existing `mondialrelay` carrier, which targets the
+older SOAP/WSI web service. The Connect API uses a different endpoint and an XML
+request/response over HTTPS:
+
+- Production: `https://connect-api.mondialrelay.com/api/shipment`
+- Sandbox: `https://connect-api-sandbox.mondialrelay.com/api/shipment`
+
+Authentication (`Login` / `Password` / `CustomerId`) is carried inside the XML
+`<Context>`, not via HTTP headers. Set `auth.isTest` to use the sandbox URL.
+
+## Action
+
+- `get_label`
+
+## Example
+
+```python
+from datetime import date
+from roulier import roulier
+
+result = roulier.get(
+    "mondialrelay_connect",
+    "get_label",
+    {
+        "auth": {"login": "BDTEST", "password": "PrivateK", "isTest": True},
+        "service": {
+            "customerId": "BDTEST",
+            "outputType": "ZplCode",
+            "labelFormat": "Generic_ZPL_10x15_203dpi",
+            "deliveryMode": "24R",
+            "deliveryLocation": "FR-66974",
+            "orderNo": "CMD123",
+        },
+        "parcels": [{"weight": 1.2, "content": "Colis"}],
+        "from_address": {
+            "name": "My Company",
+            "street1": "12 avenue du Stade",
+            "city": "Perpignan",
+            "country": "FR",
+            "zip": "66000",
+        },
+        "to_address": {
+            "name": "Jean Client",
+            "street1": "1 rue de la Paix",
+            "city": "Paris",
+            "country": "FR",
+            "zip": "75001",
+            "delivery_instruction": "Etage 3",
+        },
+    },
+)
+```
+
+## Input notes
+
+- `service.outputType`: `PdfUrl` (default), `ZplCode` or `IplCode`.
+- `service.labelFormat`: output format (e.g. `10x15`, `A4`,
+  `Generic_ZPL_10x15_203dpi`).
+- `service.deliveryMode` / `deliveryLocation`: routing, e.g. `24R` +
+  `FR-66974` for a pickup point.
+- `parcel.weight` is in kilograms (converted to grams, 10 g floor).
+- `parcel.length` / `width` / `height` are optional, in centimeters.
+- `to_address.delivery_instruction` maps to `DeliveryInstruction`.
+- Address extras: `title`, `firstname`, `lastname`, `houseNo`, `mobile`.
+
+## Output
+
+Standard roulier `get_label` output. The Connect API returns a single label
+stream for the shipment; it is attached to the first parcel, and each returned
+barcode yields a parcel entry with its tracking number.
+
+## Tests
+
+The tests run fully offline (no credentials, no network): they exercise the
+encoder (XML structure) and the decoder (sample responses) directly.
+
+```sh
+pytest roulier/carriers/mondialrelay_connect/tests/
+```

--- a/roulier/carriers/mondialrelay_connect/__init__.py
+++ b/roulier/carriers/mondialrelay_connect/__init__.py
@@ -1,0 +1,7 @@
+from . import api
+from . import encoder
+from . import decoder
+from . import transport
+from . import carrier_action
+
+# Doc: Mondial Relay "Connect" REST API (Web Service Dual Carrier).

--- a/roulier/carriers/mondialrelay_connect/api.py
+++ b/roulier/carriers/mondialrelay_connect/api.py
@@ -1,0 +1,95 @@
+"""Implementation of the Mondial Relay Connect API schema."""
+
+from roulier.api import ApiParcel
+
+from .constants import (
+    COLLECTION_MERCHANT,
+    COLLECTION_MODES,
+    DELIVERY_HOME,
+    DELIVERY_MODES,
+    OUTPUT_FORMATS,
+    OUTPUT_PDF_URL,
+    OUTPUT_TYPES,
+)
+
+
+class MondialRelayConnectApi(ApiParcel):
+    """Expected input for the Mondial Relay Connect API (get_label)."""
+
+    def _service(self):
+        schema = super()._service()
+        # Not used by this carrier: drop to avoid confusion in the public schema.
+        for field in ("agencyId", "shippingId", "shippingDate", "product"):
+            schema.pop(field, None)
+
+        # CustomerId is mandatory in the request Context.
+        schema["customerId"].update({"required": True, "empty": False})
+
+        # Localisation sent in the Context (labels language / formatting).
+        schema["culture"] = {"type": "string", "default": "fr-FR"}
+
+        # Free data printed on the label (optional). Fall back to reference1/2.
+        schema["orderNo"] = {"type": "string", "default": ""}
+        schema["customerNo"] = {"type": "string", "default": ""}
+
+        # Delivery / collection routing.
+        schema["deliveryMode"] = {
+            "type": "string",
+            "default": DELIVERY_HOME,
+            "allowed": DELIVERY_MODES,
+        }
+        schema["deliveryLocation"] = {"type": "string", "default": ""}
+        schema["collectionMode"] = {
+            "type": "string",
+            "default": COLLECTION_MERCHANT,
+            "allowed": COLLECTION_MODES,
+        }
+        schema["collectionLocation"] = {"type": "string", "default": ""}
+
+        # Label output.
+        schema["outputType"] = {
+            "type": "string",
+            "default": OUTPUT_PDF_URL,
+            "allowed": OUTPUT_TYPES,
+        }
+        schema["labelFormat"].update(
+            {
+                "type": "string",
+                "default": "10x15",
+                "allowed": OUTPUT_FORMATS,
+            }
+        )
+        return schema
+
+    def _address(self):
+        schema = super()._address()
+        # Mondial Relay address extras (all optional, mapped 1:1 onto the XML).
+        schema["title"] = {"type": "string", "default": ""}
+        schema["firstname"] = {"type": "string", "default": ""}
+        schema["lastname"] = {"type": "string", "default": ""}
+        schema["houseNo"] = {"type": "string", "default": ""}
+        schema["mobile"] = {"type": "string", "default": ""}
+        return schema
+
+    def _to_address(self):
+        schema = super()._to_address()
+        schema["country"].update({"required": True, "empty": False})
+        schema["zip"].update({"required": True, "empty": False})
+        schema["city"].update({"required": True, "empty": False})
+        return schema
+
+    def _parcel(self):
+        schema = super()._parcel()
+        # Parcel content printed on the label (<= 40 chars on the template).
+        schema["content"] = {"type": "string", "default": ""}
+        # Dimensions in centimeters (optional).
+        schema["length"] = {"type": "integer", "default": None, "nullable": True}
+        schema["width"] = {"type": "integer", "default": None, "nullable": True}
+        schema["height"] = {"type": "integer", "default": None, "nullable": True}
+        return schema
+
+    def _auth(self):
+        schema = super()._auth()
+        schema["login"].update({"required": True, "empty": False})
+        schema["password"].update({"required": True, "empty": False})
+        return schema

--- a/roulier/carriers/mondialrelay_connect/api.py
+++ b/roulier/carriers/mondialrelay_connect/api.py
@@ -7,7 +7,6 @@ from .constants import (
     COLLECTION_MODES,
     DELIVERY_HOME,
     DELIVERY_MODES,
-    OUTPUT_FORMATS,
     OUTPUT_PDF_URL,
     OUTPUT_TYPES,
 )
@@ -52,13 +51,10 @@ class MondialRelayConnectApi(ApiParcel):
             "default": OUTPUT_PDF_URL,
             "allowed": OUTPUT_TYPES,
         }
-        schema["labelFormat"].update(
-            {
-                "type": "string",
-                "default": "10x15",
-                "allowed": OUTPUT_FORMATS,
-            }
-        )
+        # Free string: the Connect API exposes many format codes depending on the
+        # output type (e.g. "10x15", "A4", "Generic_ZPL_10x15_200dpi"); see
+        # OUTPUT_FORMATS for common values. An allow-list would be too brittle.
+        schema["labelFormat"].update({"type": "string", "default": "10x15"})
         return schema
 
     def _address(self):

--- a/roulier/carriers/mondialrelay_connect/carrier_action.py
+++ b/roulier/carriers/mondialrelay_connect/carrier_action.py
@@ -1,0 +1,27 @@
+"""Mondial Relay Connect API implementation (get_label)."""
+
+from roulier.carrier_action import CarrierGetLabel
+from roulier.roulier import factory
+
+from .api import MondialRelayConnectApi
+from .decoder import MondialRelayConnectDecoder
+from .encoder import MondialRelayConnectEncoder
+from .transport import MondialRelayConnectTransport
+
+
+class MondialRelayConnectGetLabel(CarrierGetLabel):
+    """Create a shipment and its label through the Mondial Relay Connect REST API."""
+
+    ws_url = "https://connect-api.mondialrelay.com/api/shipment"
+    ws_test_url = "https://connect-api-sandbox.mondialrelay.com/api/shipment"
+    encoder = MondialRelayConnectEncoder
+    decoder = MondialRelayConnectDecoder
+    transport = MondialRelayConnectTransport
+    api = MondialRelayConnectApi
+    # One call carries the whole shipment (ParcelCount drives the labels).
+    manage_multi_label = True
+
+
+factory.register_builder(
+    "mondialrelay_connect", "get_label", MondialRelayConnectGetLabel
+)

--- a/roulier/carriers/mondialrelay_connect/constants.py
+++ b/roulier/carriers/mondialrelay_connect/constants.py
@@ -1,0 +1,58 @@
+"""Constants for Mondial Relay Connect API (Web Service Dual Carrier).
+
+Reference: Mondial Relay "Connect" REST API, ShipmentCreationRequest.
+"""
+
+# XML namespace declared in the Connect API request XSD.
+NS_REQUEST = "http://www.example.org/Request"
+
+# API version sent in the request Context.
+VERSION_API = "1.0"
+
+# Delivery modes (DeliveryMode@Mode). Non exhaustive, the most common ones.
+DELIVERY_HOME = "HOM"  # home delivery
+DELIVERY_HOME_PLUS = "HOC"  # home delivery, heavy/bulky
+DELIVERY_POINT_RELAIS = "24R"  # pickup point (requires a Location, e.g. "FR-66974")
+DELIVERY_LOCKER = "24L"  # locker
+DELIVERY_DRIVE = "DRI"  # drive
+
+DELIVERY_MODES = (
+    DELIVERY_HOME,
+    DELIVERY_HOME_PLUS,
+    DELIVERY_POINT_RELAIS,
+    DELIVERY_LOCKER,
+    DELIVERY_DRIVE,
+)
+
+# Collection modes (CollectionMode@Mode).
+COLLECTION_MERCHANT = "CCC"  # collected at the merchant
+COLLECTION_POINT_RELAIS = "REL"  # dropped at a pickup point
+
+COLLECTION_MODES = (
+    COLLECTION_MERCHANT,
+    COLLECTION_POINT_RELAIS,
+)
+
+# Output types (OutputOptions/OutputType).
+OUTPUT_PDF_URL = "PdfUrl"
+OUTPUT_ZPL = "ZplCode"
+OUTPUT_IPL = "IplCode"
+
+OUTPUT_TYPES = (
+    OUTPUT_PDF_URL,
+    OUTPUT_ZPL,
+    OUTPUT_IPL,
+)
+
+# Output formats (OutputOptions/OutputFormat). The accepted values depend on the
+# output type; these are the most common ones documented for the dual carrier API.
+OUTPUT_FORMATS = (
+    "10x15",
+    "A4",
+    "A5",
+    "Generic_PDF_10x15_300dpi",
+    "Generic_ZPL_10x15_203dpi",
+    "Generic_ZPL_10x15_300dpi",
+    "Generic_IPL_10x15_203dpi",
+    "Generic_IPL_10x15_300dpi",
+)

--- a/roulier/carriers/mondialrelay_connect/decoder.py
+++ b/roulier/carriers/mondialrelay_connect/decoder.py
@@ -41,7 +41,15 @@ class MondialRelayConnectDecoder(DecoderGetLabel):
     ):
         label = None
         if label_output:
-            label = {"data": label_output, "name": "label_1", "type": output_type}
+            # Match the roulier convention (e.g. laposte): label data is bytes.
+            # For ZplCode / IplCode the Connect API already returns base64 content,
+            # so the consumer base64-decodes it to get the raw ZPL/IPL; for PdfUrl
+            # it is a URL. The carrier output is exposed as bytes either way.
+            label = {
+                "data": label_output.encode("utf-8"),
+                "name": "label_1",
+                "type": output_type,
+            }
 
         if not barcodes:
             parcel = {

--- a/roulier/carriers/mondialrelay_connect/decoder.py
+++ b/roulier/carriers/mondialrelay_connect/decoder.py
@@ -1,0 +1,140 @@
+"""Mondial Relay Connect XML response -> roulier standard output."""
+
+import logging
+
+from lxml import etree
+
+from roulier.codec import DecoderGetLabel
+from roulier.exception import CarrierError
+
+log = logging.getLogger(__name__)
+
+
+class MondialRelayConnectDecoder(DecoderGetLabel):
+    def decode(self, response, payload):
+        output_type = payload.get("output_type", "PdfUrl")
+        root = self._parse(response["body"])
+
+        errors, warnings = self._read_statuses(root)
+        for warning in warnings:
+            log.warning("Mondial Relay Connect: %s", warning.get("message"))
+        if errors:
+            raise CarrierError(response.get("response"), errors)
+
+        shipment_number = self._read_shipment_number(root)
+        label_output = self._read_output(root)
+        barcodes = self._read_barcodes(root)
+
+        if not label_output and not barcodes:
+            raise CarrierError(
+                response.get("response"),
+                [{"id": None, "message": "No label returned by Mondial Relay Connect"}],
+            )
+
+        reference = self._get_parcel_number(payload)
+        self.result["parcels"] += self._build_parcels(
+            shipment_number, barcodes, label_output, output_type, reference
+        )
+
+    def _build_parcels(
+        self, shipment_number, barcodes, label_output, output_type, reference
+    ):
+        label = None
+        if label_output:
+            label = {"data": label_output, "name": "label_1", "type": output_type}
+
+        if not barcodes:
+            parcel = {
+                "id": shipment_number or "",
+                "reference": reference,
+                "tracking": {
+                    "number": shipment_number or "",
+                    "url": "",
+                    "partner": "",
+                },
+            }
+            if label:
+                parcel["label"] = label
+            return [parcel]
+
+        parcels = []
+        for index, barcode in enumerate(barcodes):
+            parcel = {
+                "id": barcode,
+                "reference": reference,
+                "tracking": {"number": barcode, "url": "", "partner": ""},
+            }
+            # The Connect API returns a single label stream for the shipment:
+            # attach it to the first parcel.
+            if index == 0 and label:
+                parcel["label"] = label
+            parcels.append(parcel)
+        return parcels
+
+    @staticmethod
+    def _parse(raw):
+        """Parse the response bytes, tolerating a UTF-16 declaration."""
+        if isinstance(raw, str):
+            raw = raw.encode("utf-8")
+        head = raw[:200].lower()
+        if raw[:2] in (b"\xff\xfe", b"\xfe\xff") or b'encoding="utf-16"' in head:
+            text = raw.decode("utf-16")
+        else:
+            text = raw.decode("utf-8", errors="replace")
+        # Drop the declaration so lxml does not complain about the encoding of a
+        # str, then parse.
+        text = text.lstrip("﻿")
+        parser = etree.XMLParser(recover=True, resolve_entities=False)
+        return etree.fromstring(text.encode("utf-8"), parser=parser)
+
+    def _read_statuses(self, root):
+        errors = []
+        warnings = []
+        for status in root.xpath("//*[local-name()='Status']"):
+            code = self._field(status, "code")
+            level = self._field(status, "level").lower()
+            message = self._field(status, "message")
+            entry = {"id": code or None, "message": message, "level": level}
+            if "error" in level:
+                errors.append(entry)
+            elif "warn" in level:
+                warnings.append(entry)
+            # Success / info statuses are ignored.
+        return errors, warnings
+
+    @staticmethod
+    def _read_shipment_number(root):
+        nodes = root.xpath("//*[local-name()='Shipment']")
+        for node in nodes:
+            number = node.get("ShipmentNumber")
+            if number:
+                return number
+        return None
+
+    @staticmethod
+    def _read_output(root):
+        nodes = root.xpath("//*[local-name()='Output']")
+        if nodes and nodes[0].text:
+            return nodes[0].text.strip()
+        return None
+
+    @staticmethod
+    def _read_barcodes(root):
+        barcodes = []
+        for node in root.xpath("//*[local-name()='Barcode']"):
+            value = node.get("Value") or (node.text or "").strip()
+            if value:
+                barcodes.append(value)
+        return barcodes
+
+    @staticmethod
+    def _field(node, name):
+        """Read a status field as an attribute or a child, case-insensitively."""
+        for attr, value in node.attrib.items():
+            if attr.lower() == name:
+                return value.strip()
+        for child in node:
+            tag = etree.QName(child).localname.lower()
+            if tag == name and child.text:
+                return child.text.strip()
+        return ""

--- a/roulier/carriers/mondialrelay_connect/decoder.py
+++ b/roulier/carriers/mondialrelay_connect/decoder.py
@@ -68,9 +68,15 @@ class MondialRelayConnectDecoder(DecoderGetLabel):
         parcels = []
         for index, barcode in enumerate(barcodes):
             parcel = {
+                # The linear Barcode value is the routing barcode printed on the
+                # label; the tracking reference is the shipment (expedition) number.
                 "id": barcode,
                 "reference": reference,
-                "tracking": {"number": barcode, "url": "", "partner": ""},
+                "tracking": {
+                    "number": shipment_number or barcode,
+                    "url": "",
+                    "partner": "",
+                },
             }
             # The Connect API returns a single label stream for the shipment:
             # attach it to the first parcel.

--- a/roulier/carriers/mondialrelay_connect/encoder.py
+++ b/roulier/carriers/mondialrelay_connect/encoder.py
@@ -1,0 +1,137 @@
+"""Transform roulier input into a Mondial Relay Connect XML request."""
+
+import logging
+
+from lxml import etree
+
+from roulier.codec import Encoder
+
+from .constants import NS_REQUEST, VERSION_API
+
+_logger = logging.getLogger(__name__)
+
+# Sequence of the <Address> children, conforming to the request XSD.
+# Each tuple is (xml_tag, roulier_address_field). AddressAdd1 carries the name and
+# is the only mandatory address field for Mondial Relay.
+_ADDRESS_FIELDS = (
+    ("Title", "title"),
+    ("Firstname", "firstname"),
+    ("Lastname", "lastname"),
+    ("Streetname", "street1"),
+    ("HouseNo", "houseNo"),
+    ("CountryCode", "country"),
+    ("PostCode", "zip"),
+    ("City", "city"),
+    ("AddressAdd1", "name"),
+    ("AddressAdd2", "company"),
+    ("AddressAdd3", "street2"),
+    ("PhoneNo", "phone"),
+    ("MobileNo", "mobile"),
+    ("Email", "email"),
+)
+
+
+class MondialRelayConnectEncoder(Encoder):
+    def transform_input_to_carrier_webservice(self, data):
+        service = data["service"]
+        parcels = data["parcels"]
+
+        root = etree.Element(
+            "{%s}ShipmentCreationRequest" % NS_REQUEST,
+            nsmap={
+                None: NS_REQUEST,
+                "xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                "xsd": "http://www.w3.org/2001/XMLSchema",
+            },
+        )
+
+        self._add_context(root, data)
+        self._add_output_options(root, service)
+
+        shipments = etree.SubElement(root, "ShipmentsList")
+        shipment = etree.SubElement(shipments, "Shipment")
+        self._add_shipment(shipment, data, service, parcels)
+
+        body = etree.tostring(
+            root, xml_declaration=True, encoding="utf-8", pretty_print=False
+        )
+        return {
+            "body": body,
+            "output_type": service["outputType"],
+            "label_format": service["labelFormat"],
+        }
+
+    def _add_context(self, root, data):
+        ctx = etree.SubElement(root, "Context")
+        self._text(ctx, "Login", data["auth"]["login"])
+        self._text(ctx, "Password", data["auth"]["password"])
+        self._text(ctx, "CustomerId", data["service"]["customerId"])
+        self._text(ctx, "Culture", data["service"]["culture"])
+        self._text(ctx, "VersionAPI", VERSION_API)
+
+    def _add_output_options(self, root, service):
+        out = etree.SubElement(root, "OutputOptions")
+        self._text(out, "OutputFormat", service["labelFormat"])
+        self._text(out, "OutputType", service["outputType"])
+
+    def _add_shipment(self, shipment, data, service, parcels):
+        order_no = service["orderNo"] or service.get("reference1", "")
+        customer_no = service["customerNo"] or service.get("reference2", "")
+        if order_no:
+            self._text(shipment, "OrderNo", order_no)
+        if customer_no:
+            self._text(shipment, "CustomerNo", customer_no)
+        self._text(shipment, "ParcelCount", str(max(1, len(parcels))))
+
+        delivery = etree.SubElement(shipment, "DeliveryMode")
+        delivery.set("Mode", service["deliveryMode"])
+        delivery.set("Location", service["deliveryLocation"])
+
+        collection = etree.SubElement(shipment, "CollectionMode")
+        collection.set("Mode", service["collectionMode"])
+        collection.set("Location", service["collectionLocation"])
+
+        # Mondial Relay Connect carries a single weight/dimensions block for the
+        # shipment; ParcelCount above drives the number of printed labels.
+        self._add_parcel(shipment, parcels[0])
+
+        instruction = data["to_address"].get("delivery_instruction", "")
+        if instruction:
+            self._text(shipment, "DeliveryInstruction", instruction)
+
+        sender = etree.SubElement(shipment, "Sender")
+        self._add_address(sender, data.get("from_address", {}))
+        recipient = etree.SubElement(shipment, "Recipient")
+        self._add_address(recipient, data["to_address"])
+
+    def _add_parcel(self, shipment, parcel):
+        parcels_node = etree.SubElement(shipment, "Parcels")
+        parcel_node = etree.SubElement(parcels_node, "Parcel")
+        if parcel.get("content"):
+            self._text(parcel_node, "Content", parcel["content"])
+
+        weight = etree.SubElement(parcel_node, "Weight")
+        grams = max(10, int(round(float(parcel["weight"]) * 1000)))
+        weight.set("Value", str(grams))
+        weight.set("Unit", "gr")
+
+        for tag, field in (("Length", "length"), ("Width", "width"), ("Depth", "height")):
+            value = parcel.get(field)
+            if value:
+                dim = etree.SubElement(parcel_node, tag)
+                dim.set("Value", str(int(value)))
+                dim.set("Unit", "cm")
+
+    def _add_address(self, parent, address):
+        addr = etree.SubElement(parent, "Address")
+        for tag, field in _ADDRESS_FIELDS:
+            # All tags are emitted, empty ones included (the API tolerates them and
+            # the XSD expects the full sequence).
+            self._text(addr, tag, address.get(field, ""))
+
+    @staticmethod
+    def _text(parent, tag, value):
+        el = etree.SubElement(parent, tag)
+        if value not in (None, ""):
+            el.text = str(value)
+        return el

--- a/roulier/carriers/mondialrelay_connect/tests/__init__.py
+++ b/roulier/carriers/mondialrelay_connect/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_connect

--- a/roulier/carriers/mondialrelay_connect/tests/data.py
+++ b/roulier/carriers/mondialrelay_connect/tests/data.py
@@ -58,7 +58,7 @@ RESPONSE_OK = b"""<?xml version="1.0" encoding="utf-8"?>
     <Status Level="Success" Code="0" Message="Operation successful"/>
   </StatusList>
   <ShipmentsList>
-    <Shipment ShipmentNumber="29A00012345">
+    <Shipment ShipmentNumber="71723325">
       <LabelList>
         <Label>
           <Output>^XA^FO50,50^FDMR^FS^XZ</Output>
@@ -66,7 +66,7 @@ RESPONSE_OK = b"""<?xml version="1.0" encoding="utf-8"?>
       </LabelList>
       <ParcelList>
         <Parcel>
-          <Barcode Value="29A00012345"/>
+          <Barcode Value="62717233250101207693148140"/>
         </Parcel>
       </ParcelList>
     </Shipment>

--- a/roulier/carriers/mondialrelay_connect/tests/data.py
+++ b/roulier/carriers/mondialrelay_connect/tests/data.py
@@ -1,0 +1,84 @@
+"""Sample input and responses for the Mondial Relay Connect tests.
+
+These tests run fully offline (no credentials, no network): the encoder and the
+decoder are exercised directly.
+"""
+
+DATA = {
+    "auth": {
+        "login": "BDTEST",
+        "password": "PrivateK",
+        "isTest": True,
+    },
+    "service": {
+        "customerId": "BDTEST",
+        "outputType": "ZplCode",
+        "labelFormat": "Generic_ZPL_10x15_203dpi",
+        "deliveryMode": "24R",
+        "deliveryLocation": "FR-66974",
+        "collectionMode": "CCC",
+        "orderNo": "CMD123",
+        "customerNo": "CLI1",
+    },
+    "parcels": [
+        {
+            "weight": 1.2,
+            "content": "Colis",
+            "reference": "PARCEL-1",
+            "length": 30,
+            "width": 20,
+            "height": 10,
+        }
+    ],
+    "from_address": {
+        "name": "Domadoo",
+        "street1": "12 avenue du Stade",
+        "city": "Perpignan",
+        "country": "FR",
+        "zip": "66000",
+        "email": "logistique@example.com",
+    },
+    "to_address": {
+        "name": "Jean Client",
+        "street1": "1 rue de la Paix",
+        "street2": "Batiment B",
+        "city": "Paris",
+        "country": "FR",
+        "zip": "75001",
+        "email": "jean@example.com",
+        "phone": "0102030405",
+        "delivery_instruction": "Etage 3, digicode 1234",
+    },
+}
+
+# Minimal but representative success response (ZPL output + barcode).
+RESPONSE_OK = b"""<?xml version="1.0" encoding="utf-8"?>
+<ShipmentCreationResponse xmlns="http://www.example.org/Response">
+  <StatusList>
+    <Status Level="Success" Code="0" Message="Operation successful"/>
+  </StatusList>
+  <ShipmentsList>
+    <Shipment ShipmentNumber="29A00012345">
+      <LabelList>
+        <Label>
+          <Output>^XA^FO50,50^FDMR^FS^XZ</Output>
+        </Label>
+      </LabelList>
+      <ParcelList>
+        <Parcel>
+          <Barcode Value="29A00012345"/>
+        </Parcel>
+      </ParcelList>
+    </Shipment>
+  </ShipmentsList>
+</ShipmentCreationResponse>
+"""
+
+# Business error response (HTTP 200, error carried as a Status node).
+RESPONSE_ERROR = b"""<?xml version="1.0" encoding="utf-8"?>
+<ShipmentCreationResponse xmlns="http://www.example.org/Response">
+  <StatusList>
+    <Status Level="Error" Code="30" Message="Invalid postcode"/>
+  </StatusList>
+</ShipmentCreationResponse>
+"""

--- a/roulier/carriers/mondialrelay_connect/tests/data.py
+++ b/roulier/carriers/mondialrelay_connect/tests/data.py
@@ -31,7 +31,7 @@ DATA = {
         }
     ],
     "from_address": {
-        "name": "Domadoo",
+        "name": "Example Logistics",
         "street1": "12 avenue du Stade",
         "city": "Perpignan",
         "country": "FR",

--- a/roulier/carriers/mondialrelay_connect/tests/test_connect.py
+++ b/roulier/carriers/mondialrelay_connect/tests/test_connect.py
@@ -100,7 +100,9 @@ def test_decode_success():
     )
     parcels = decoder.result["parcels"]
     assert len(parcels) == 1
-    assert parcels[0]["tracking"]["number"] == "29A00012345"
+    # Tracking = shipment (expedition) number, NOT the routing barcode.
+    assert parcels[0]["tracking"]["number"] == "71723325"
+    assert parcels[0]["id"] == "62717233250101207693148140"
     assert parcels[0]["reference"] == "PARCEL-1"
     assert parcels[0]["label"]["type"] == "ZplCode"
     # Label data is bytes (roulier convention); the fixture Output is raw ZPL.

--- a/roulier/carriers/mondialrelay_connect/tests/test_connect.py
+++ b/roulier/carriers/mondialrelay_connect/tests/test_connect.py
@@ -1,0 +1,116 @@
+"""Offline tests for the Mondial Relay Connect carrier."""
+
+import copy
+
+import pytest
+from lxml import etree
+
+from roulier import roulier
+from roulier.roulier import factory
+from roulier.exception import CarrierError, InvalidApiInput
+
+from .data import DATA, RESPONSE_ERROR, RESPONSE_OK
+
+
+def _text(root, tag):
+    nodes = root.xpath("//*[local-name()=$t]", t=tag)
+    return nodes[0].text if nodes else None
+
+
+def _node(root, tag):
+    nodes = root.xpath("//*[local-name()=$t]", t=tag)
+    return nodes[0] if nodes else None
+
+
+def test_carrier_registered():
+    available = roulier.get_carriers_action_available()
+    assert "mondialrelay_connect" in available
+    assert available["mondialrelay_connect"] == ["get_label"]
+
+
+def test_invalid_input_missing_recipient_zip():
+    vals = copy.deepcopy(DATA)
+    del vals["to_address"]["zip"]
+    with pytest.raises(InvalidApiInput):
+        carrier = factory.get("mondialrelay_connect", "get_label")
+        carrier.encoder(carrier).encode(vals)
+
+
+def test_invalid_delivery_mode():
+    vals = copy.deepcopy(DATA)
+    vals["service"]["deliveryMode"] = "NOPE"
+    with pytest.raises(InvalidApiInput):
+        carrier = factory.get("mondialrelay_connect", "get_label")
+        carrier.encoder(carrier).encode(vals)
+
+
+def test_encode_request_structure():
+    carrier = factory.get("mondialrelay_connect", "get_label")
+    payload = carrier.encoder(carrier).encode(copy.deepcopy(DATA))
+    root = etree.fromstring(payload["body"])
+
+    # Context.
+    assert _text(root, "Login") == "BDTEST"
+    assert _text(root, "CustomerId") == "BDTEST"
+    assert _text(root, "Culture") == "fr-FR"
+    assert _text(root, "VersionAPI") == "1.0"
+
+    # Output options.
+    assert _text(root, "OutputType") == "ZplCode"
+    assert _text(root, "OutputFormat") == "Generic_ZPL_10x15_203dpi"
+
+    # Shipment routing + free data.
+    assert _text(root, "OrderNo") == "CMD123"
+    assert _text(root, "CustomerNo") == "CLI1"
+    assert _text(root, "ParcelCount") == "1"
+    delivery = _node(root, "DeliveryMode")
+    assert delivery.get("Mode") == "24R"
+    assert delivery.get("Location") == "FR-66974"
+
+    # Weight in grams, dimensions in cm.
+    weight = _node(root, "Weight")
+    assert weight.get("Value") == "1200"
+    assert weight.get("Unit") == "gr"
+    assert _node(root, "Length").get("Value") == "30"
+
+    # Recipient mapping + delivery instruction.
+    assert _text(root, "DeliveryInstruction") == "Etage 3, digicode 1234"
+    recipient = root.xpath("//*[local-name()='Recipient']")[0]
+    add1 = recipient.xpath(".//*[local-name()='AddressAdd1']")[0]
+    add3 = recipient.xpath(".//*[local-name()='AddressAdd3']")[0]
+    assert add1.text == "Jean Client"
+    assert add3.text == "Batiment B"
+
+
+def test_encode_weight_floor():
+    vals = copy.deepcopy(DATA)
+    vals["parcels"][0]["weight"] = 0.001  # below the 10 g floor
+    carrier = factory.get("mondialrelay_connect", "get_label")
+    payload = carrier.encoder(carrier).encode(vals)
+    root = etree.fromstring(payload["body"])
+    assert _node(root, "Weight").get("Value") == "10"
+
+
+def test_decode_success():
+    carrier = factory.get("mondialrelay_connect", "get_label")
+    carrier.roulier_input = copy.deepcopy(DATA)
+    decoder = carrier.decoder(carrier)
+    decoder.decode(
+        {"body": RESPONSE_OK, "response": None}, {"output_type": "ZplCode"}
+    )
+    parcels = decoder.result["parcels"]
+    assert len(parcels) == 1
+    assert parcels[0]["tracking"]["number"] == "29A00012345"
+    assert parcels[0]["reference"] == "PARCEL-1"
+    assert parcels[0]["label"]["type"] == "ZplCode"
+    assert "^XA" in parcels[0]["label"]["data"]
+
+
+def test_decode_business_error():
+    carrier = factory.get("mondialrelay_connect", "get_label")
+    carrier.roulier_input = copy.deepcopy(DATA)
+    decoder = carrier.decoder(carrier)
+    with pytest.raises(CarrierError, match="Invalid postcode"):
+        decoder.decode(
+            {"body": RESPONSE_ERROR, "response": None}, {"output_type": "ZplCode"}
+        )

--- a/roulier/carriers/mondialrelay_connect/tests/test_connect.py
+++ b/roulier/carriers/mondialrelay_connect/tests/test_connect.py
@@ -103,7 +103,8 @@ def test_decode_success():
     assert parcels[0]["tracking"]["number"] == "29A00012345"
     assert parcels[0]["reference"] == "PARCEL-1"
     assert parcels[0]["label"]["type"] == "ZplCode"
-    assert "^XA" in parcels[0]["label"]["data"]
+    # Label data is bytes (roulier convention); the fixture Output is raw ZPL.
+    assert parcels[0]["label"]["data"] == b"^XA^FO50,50^FDMR^FS^XZ"
 
 
 def test_decode_business_error():

--- a/roulier/carriers/mondialrelay_connect/transport.py
+++ b/roulier/carriers/mondialrelay_connect/transport.py
@@ -1,0 +1,58 @@
+"""Mondial Relay Connect transport: POST an XML body over HTTPS."""
+
+import logging
+
+from roulier.exception import CarrierError
+from roulier.transport import RequestsTransport
+
+log = logging.getLogger(__name__)
+
+
+class MondialRelayConnectTransport(RequestsTransport):
+    """Send the XML request to the Connect REST endpoint.
+
+    Authentication is carried inside the XML <Context> (Login/Password/CustomerId),
+    not via HTTP headers.
+    """
+
+    def before_ws_call_transform_payload(self, payload):
+        return payload["body"]
+
+    def _get_requests_headers(self, payload=None):
+        return {
+            "Content-Type": "text/xml; charset=utf-8",
+            "Accept": "application/xml",
+        }
+
+    def _handle_response(self, response):
+        # Mondial Relay returns 200 even for business errors (carried as <Status>
+        # nodes inside the body), so success/failure is decided by the decoder.
+        # Keep the raw bytes: the response may be declared as UTF-16.
+        return {"body": response.content, "response": response}
+
+    def handle_200(self, response):
+        return self._handle_response(response)
+
+    def handle_2XX(self, response):
+        return self._handle_response(response)
+
+    def _handle_error(self, response):
+        raise CarrierError(
+            response,
+            [
+                {
+                    "id": "http_%d" % response.status_code,
+                    "message": "Mondial Relay Connect HTTP error %d: %s"
+                    % (response.status_code, response.reason),
+                }
+            ],
+        )
+
+    def handle_500(self, response):
+        return self._handle_error(response)
+
+    def handle_4XX(self, response):
+        return self._handle_error(response)
+
+    def handle_5XX(self, response):
+        return self._handle_error(response)


### PR DESCRIPTION
This pull request adds support for the Mondial Relay Connect REST API (Web Service Dual Carrier) as a new carrier integration. It introduces a new module, `mondialrelay_connect`, which implements label creation through the Connect API, including encoder/decoder logic, constants, and tests. The integration is distinct from the older Mondial Relay SOAP/WSI service and includes comprehensive documentation and offline test coverage.

**New Carrier Integration: Mondial Relay Connect**
- Added a new carrier module, `mondialrelay_connect`, providing support for the Mondial Relay Connect REST API for label creation, including registration in the carrier list (`__init__.py`). [[1]](diffhunk://#diff-2c08819aa25a549eda3fa3b8b7a6c676d44c2f8b89ef5adcf505e87a255c70ebR10) [[2]](diffhunk://#diff-8993dcb2fe0f4eb0db0f8b766c9d181f1091d71b8c38ea6778307050b81ad7d7R1-R7)
- Implemented the main API schema and validation in `api.py`, including input structure, required fields, and supported options for label creation.
- Added encoder (`encoder.py`) and decoder (`decoder.py`) to handle XML request/response transformation between the roulier standard and the Connect API. [[1]](diffhunk://#diff-bd10b9221959310749586fee53d43b35440fe2e88ac561299e276f9ca3cd2545R1-R137) [[2]](diffhunk://#diff-75a9817223d9e3243fa94526f053b3131fd6552972f26890843dd8794fb3f539R1-R154)
- Defined constants for delivery/collection modes, output types, and formats in `constants.py`.
- Registered the `get_label` action for the new carrier in `carrier_action.py`, enabling label creation and shipment handling.

**Documentation and Testing**
- Added a detailed `README.md` for `mondialrelay_connect`, explaining usage, input/output, and providing example code.
- Introduced offline tests for the new carrier, including sample data and example responses, ensuring encoder/decoder correctness without network access. [[1]](diffhunk://#diff-81016518d8e240e416192ab35fff912b34aea66776ff1a8a8273c2755a41fe06R1) [[2]](diffhunk://#diff-887fdb92a7224b407d087b43187648cdd6f8ae8c3ffa0e5cc98175176ed5c5afR1-R84)

**Project Changelog**
- Updated `CHANGELOG.md` to document the addition of the Mondial Relay Connect REST API integration.